### PR TITLE
Enable parsing unencrypted 802.11 RadioTap packets such as those captured by interfaces in monitor mode.

### DIFF
--- a/PacketDotNet/Ieee80211/DataDataFrame.cs
+++ b/PacketDotNet/Ieee80211/DataDataFrame.cs
@@ -68,14 +68,6 @@ namespace PacketDotNet
                 SequenceControl = new SequenceControlField (SequenceControlBytes);
                 ReadAddresses (); //must do this after reading FrameControl
 
-                //header.Length = FrameSize; 
-                //var availablePayloadLength = GetAvailablePayloadLength();
-                //if(availablePayloadLength > 0)
-                //{
-                //    payloadPacketOrData.TheByteArraySegment = header.EncapsulatedBytes (availablePayloadLength);
-                //}
-
-
                 header.Length = FrameSize;
                 var availablePayloadLength = GetAvailablePayloadLength();
                 if (availablePayloadLength > SNAPFields.HeaderLength)

--- a/PacketDotNet/Ieee80211/DataDataFrame.cs
+++ b/PacketDotNet/Ieee80211/DataDataFrame.cs
@@ -68,12 +68,24 @@ namespace PacketDotNet
                 SequenceControl = new SequenceControlField (SequenceControlBytes);
                 ReadAddresses (); //must do this after reading FrameControl
 
-                header.Length = FrameSize; 
+                //header.Length = FrameSize; 
+                //var availablePayloadLength = GetAvailablePayloadLength();
+                //if(availablePayloadLength > 0)
+                //{
+                //    payloadPacketOrData.TheByteArraySegment = header.EncapsulatedBytes (availablePayloadLength);
+                //}
+
+
+                header.Length = FrameSize;
                 var availablePayloadLength = GetAvailablePayloadLength();
-				if(availablePayloadLength > 0)
-				{
-					payloadPacketOrData.TheByteArraySegment = header.EncapsulatedBytes (availablePayloadLength);
-				}
+                if (availablePayloadLength > SNAPFields.HeaderLength)
+                {
+                    payloadPacketOrData.ThePacket = new SNAPPacket(header.EncapsulatedBytes(availablePayloadLength));
+                }
+                else
+                {
+                    payloadPacketOrData.TheByteArraySegment = header.EncapsulatedBytes(availablePayloadLength);
+                }
             }
             
             /// <summary>

--- a/PacketDotNet/Ieee80211/QosDataFrame.cs
+++ b/PacketDotNet/Ieee80211/QosDataFrame.cs
@@ -114,13 +114,17 @@ namespace PacketDotNet
                 SequenceControl = new SequenceControlField (SequenceControlBytes);
                 QosControl = QosControlBytes;
                 ReadAddresses ();
-                
+
                 header.Length = FrameSize;
                 var availablePayloadLength = GetAvailablePayloadLength();
-                if(availablePayloadLength > 0)
-				{
-					payloadPacketOrData.TheByteArraySegment = header.EncapsulatedBytes (availablePayloadLength);
-				}
+                if (availablePayloadLength > SNAPFields.HeaderLength)
+                {
+                    payloadPacketOrData.ThePacket = new SNAPPacket(header.EncapsulatedBytes(availablePayloadLength));
+                }
+                else
+                {
+                    payloadPacketOrData.TheByteArraySegment = header.EncapsulatedBytes(availablePayloadLength);
+                }
             }
             
             /// <summary>

--- a/PacketDotNet/MiscUtil/Conversion/EndianBitConverter.cs
+++ b/PacketDotNet/MiscUtil/Conversion/EndianBitConverter.cs
@@ -123,6 +123,17 @@ namespace MiscUtil.Conversion
         }
 
         /// <summary>
+        /// Returns a byte converted at a specified position in a byte array.
+        /// </summary>
+        /// <param name="value">An array of bytes.</param>
+        /// <param name="startIndex">The starting position within value.</param>
+        /// <returns>A character formed by two bytes beginning at startIndex.</returns>
+        public char ToByte(byte[] value, int startIndex)
+        {
+            return unchecked((char)(CheckedFromBytes(value, startIndex, 1)));
+        }
+
+        /// <summary>
         /// Returns a double-precision floating point number converted from eight bytes
         /// at a specified position in a byte array.
         /// </summary>

--- a/PacketDotNet/PacketDotNet.csproj
+++ b/PacketDotNet/PacketDotNet.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -45,6 +45,8 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="ApplicationPacket.cs" />
+    <Compile Include="SNAPFields.cs" />
+    <Compile Include="SNAPPacket.cs" />
     <Compile Include="Ieee80211\ActionFrame.cs" />
     <Compile Include="Ieee80211\ReassociationRequestFrame.cs" />
     <Compile Include="Ieee80211\BlockAcknowledgmentControlField.cs" />

--- a/PacketDotNet/SNAPFields.cs
+++ b/PacketDotNet/SNAPFields.cs
@@ -1,0 +1,73 @@
+/*
+This file is part of PacketDotNet
+
+PacketDotNet is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PacketDotNet is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
+ *  Copyright 2016 Joseph D. Beshay <josephdbeshay@gmail.com>
+ */
+using System;
+
+namespace PacketDotNet
+{
+    /// <summary>
+    /// LLC+SNAP protocol field encoding information.
+    /// </summary>
+    public class SNAPFields
+    {
+        /// <summary> Width of the Destination Service Access Point in bytes.</summary>
+        public readonly static int DSAPLength = 1;
+
+        /// <summary> Width of the Source Service Access Point in bytes.</summary>
+        public readonly static int SSAPLength = 1;
+
+        /// <summary> Width of the Control field in bytes.</summary>
+        public readonly static int ControlLength = 1;
+
+        /// <summary> Width of the Organization Code in bytes.</summary>
+        public readonly static int OrgCodeLength = 3;
+
+        /// <summary> Width of the Ethernet Type in bytes.</summary>
+        public readonly static int EtherTypeLength = 2;
+
+        /// <summary> Position of the DSAP address within the SNAP header.</summary>
+        public readonly static int DSAPPosition = 0;
+
+        /// <summary> Position of the SSAP address within the SNAP header.</summary>
+        public readonly static int SSAPPosition;
+
+        /// <summary> Position of the Control field within the SNAP header.</summary>
+        public readonly static int ControlPosition;
+
+        /// <summary> Position of the Organization code within the SNAP header.</summary>
+        public readonly static int OrgCodePosition;
+
+        /// <summary> Position of the ethernet type field within the SNAP header.</summary>
+        public readonly static int EtherTypePosition;
+
+        /// <summary> Total length of a SNAP header in bytes.</summary>
+        public readonly static int HeaderLength; // == 8
+
+        static SNAPFields()
+        {
+            SSAPPosition = SNAPFields.DSAPPosition + SNAPFields.DSAPLength;
+            ControlPosition = SNAPFields.SSAPPosition + SNAPFields.SSAPLength;
+            OrgCodePosition = SNAPFields.ControlPosition + SNAPFields.ControlLength;
+            EtherTypePosition = SNAPFields.OrgCodePosition + SNAPFields.OrgCodeLength;
+            HeaderLength = SNAPFields.EtherTypePosition + SNAPFields.EtherTypeLength;
+            
+        }
+    }
+}

--- a/PacketDotNet/SNAPPacket.cs
+++ b/PacketDotNet/SNAPPacket.cs
@@ -1,0 +1,373 @@
+/*
+This file is part of PacketDotNet
+
+PacketDotNet is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PacketDotNet is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
+ *  Copyright 2016 Joseph D. Beshay <josephdbeshay@gmail.com>
+ *  
+ */
+﻿using System;
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
+using System.Text;
+using PacketDotNet.Utils;
+using MiscUtil.Conversion;
+
+namespace PacketDotNet
+{
+    /// <summary>
+    /// See https://en.wikipedia.org/wiki/Subnetwork_Access_Protocol
+    /// </summary>
+    [Serializable]
+    public class SNAPPacket : InternetLinkLayerPacket
+    {
+#if DEBUG
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+#else
+        // NOTE: No need to warn about lack of use, the compiler won't
+        //       put any calls to 'log' here but we need 'log' to exist to compile
+#pragma warning disable 0169, 0649
+        private static readonly ILogInactive log;
+#pragma warning restore 0169, 0649
+#endif
+
+        /// <value>
+        /// Destination Service Access Point
+        /// </value>
+        public virtual byte DSAP 
+        { 
+            get 
+            {
+                return (byte)EndianBitConverter.Big.ToByte(header.Bytes, header.Offset + SNAPFields.DSAPPosition);
+            }
+            set
+            {
+                EndianBitConverter.Big.CopyBytes((char) value, header.Bytes, header.Offset + SNAPFields.DSAPPosition);
+            }
+        }
+
+        /// <value>
+        /// Source Service Access Point
+        /// </value>
+        public virtual byte SSAP 
+        { 
+            get 
+            {
+                return (byte) EndianBitConverter.Big.ToByte(header.Bytes, header.Offset + SNAPFields.SSAPPosition);
+            }
+            set
+            {
+                EndianBitConverter.Big.CopyBytes((char) value, header.Bytes, header.Offset + SNAPFields.SSAPPosition);
+            }
+        }
+
+        /// <value>
+        /// Control Field for this SNAP packet.
+        /// </value>
+        public virtual byte ControlField
+        { 
+            get 
+            {
+                return (byte)EndianBitConverter.Big.ToByte(header.Bytes, header.Offset + SNAPFields.ControlPosition);
+            }
+            set
+            {
+                EndianBitConverter.Big.CopyBytes((char) value, header.Bytes, header.Offset + SNAPFields.ControlPosition);
+            }
+        }
+
+        /// <value>
+        /// Oragnization Code of packet that this SNAP packet encapsulates
+        /// </value>
+        public virtual int OrgCode
+        { 
+            get 
+            {
+                byte[] temp = new byte[4];
+                Array.Copy(header.Bytes, header.Offset + SNAPFields.OrgCodePosition, temp, 1, SNAPFields.OrgCodeLength);
+                return EndianBitConverter.Big.ToInt32(temp, 0);
+            }
+            set
+            {
+                byte[] temp = new byte[4];
+                EndianBitConverter.Big.CopyBytes(value, temp, 0);
+                Array.Copy(temp, 1, header.Bytes, header.Offset + SNAPFields.OrgCodePosition, SNAPFields.OrgCodeLength);
+            }
+        }
+
+        /// <value>
+        /// Type of packet that this SNAP packet encapsulates
+        /// </value>
+        public virtual EthernetPacketType EtherType
+        {
+            get
+            {
+                return (EthernetPacketType)EndianBitConverter.Big.ToInt16(header.Bytes,
+                                                                          header.Offset + SNAPFields.EtherTypePosition);
+            }
+
+            set
+            {
+                Int16 val = (Int16)value;
+                EndianBitConverter.Big.CopyBytes(val,
+                                                 header.Bytes,
+                                                 header.Offset + SNAPFields.EtherTypePosition);
+            }
+        }
+
+
+        /// <value>
+        /// Payload packet, overridden to set the 'EtherType' field based on
+        /// the type of packet being used here if the PayloadPacket is being set
+        /// </value>
+        public override Packet PayloadPacket
+        {
+            get
+            {
+                return base.PayloadPacket;
+            }
+
+            set
+            {
+                base.PayloadPacket = value;
+
+                // set Type based on the type of the payload
+                if(value is IPv4Packet)
+                {
+                    EtherType = EthernetPacketType.IpV4;
+                } else if(value is IPv6Packet)
+                {
+                    EtherType = EthernetPacketType.IpV6;
+                } else if(value is ARPPacket)
+                {
+                    EtherType = EthernetPacketType.Arp;
+                }
+                else if(value is LLDPPacket)
+                {
+                    EtherType = EthernetPacketType.LLDP;
+                }
+                else if(value is PPPoEPacket)
+                {
+                    EtherType = EthernetPacketType.PointToPointProtocolOverEthernetSessionStage;
+                }
+                else // NOTE: new types should be inserted here
+                {
+                    EtherType = EthernetPacketType.None;
+                }
+            }
+        }
+
+        
+
+        /// <summary>
+        /// Construct a new SNAP packet holding a logical ethernet packet.
+        /// </summary>
+        public SNAPPacket(byte DSAP,
+                              byte SSAP,
+                              byte Control, 
+                              int OrgCode,
+                              EthernetPacketType ethernetType)
+        {
+            log.Debug("");
+
+            // allocate memory for this packet
+            int offset = 0;
+            int length = SNAPFields.HeaderLength;
+            var headerBytes = new byte[length];
+            header = new ByteArraySegment(headerBytes, offset, length);
+
+            // set the instance values
+            this.DSAP = DSAP;
+            this.SSAP = SSAP;
+            this.ControlField = Control;
+            this.OrgCode = OrgCode;
+            this.EtherType = ethernetType;
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="bas">
+        /// A <see cref="ByteArraySegment"/>
+        /// </param>
+        public SNAPPacket(ByteArraySegment bas)
+        {
+            log.Debug("");
+
+            // slice off the header portion
+            header = new ByteArraySegment(bas);
+            header.Length = SNAPFields.HeaderLength;
+
+            // parse the encapsulated bytes
+            payloadPacketOrData = ParseEncapsulatedBytes(header, EtherType);
+        }
+
+        /// <summary>
+        /// Used by the SNAPPacket constructor. Located here because the LinuxSLL constructor
+        /// also needs to perform the same operations as it contains an ethernet type
+        /// </summary>
+        /// <param name="Header">
+        /// A <see cref="ByteArraySegment"/>
+        /// </param>
+        /// <param name="Type">
+        /// A <see cref="EthernetPacketType"/>
+        /// </param>
+        /// <returns>
+        /// A <see cref="PacketOrByteArraySegment"/>
+        /// </returns>
+        internal static PacketOrByteArraySegment ParseEncapsulatedBytes(ByteArraySegment Header,
+                                                                        EthernetPacketType Type)
+        {
+            // slice off the payload
+            var payload = Header.EncapsulatedBytes();
+            log.DebugFormat("payload {0}", payload.ToString());
+
+            var payloadPacketOrData = new PacketOrByteArraySegment();
+
+            // parse the encapsulated bytes
+            switch(Type)
+            {
+            case EthernetPacketType.IpV4:
+                payloadPacketOrData.ThePacket = new IPv4Packet(payload);
+                break;
+            case EthernetPacketType.IpV6:
+                payloadPacketOrData.ThePacket = new IPv6Packet(payload);
+                break;
+            case EthernetPacketType.Arp:
+                payloadPacketOrData.ThePacket = new ARPPacket(payload);
+                break;
+            case EthernetPacketType.LLDP:
+                payloadPacketOrData.ThePacket = new LLDPPacket(payload);
+                break;
+            case EthernetPacketType.PointToPointProtocolOverEthernetSessionStage:
+                payloadPacketOrData.ThePacket = new PPPoEPacket(payload);
+                break;
+            case EthernetPacketType.WakeOnLan:
+                payloadPacketOrData.ThePacket = new WakeOnLanPacket(payload);
+                break;
+            case EthernetPacketType.VLanTaggedFrame:
+                payloadPacketOrData.ThePacket = new Ieee8021QPacket(payload);
+                break;
+            default: // consider the sub-packet to be a byte array
+                payloadPacketOrData.TheByteArraySegment = payload;
+                break;
+            }
+
+            return payloadPacketOrData;
+        }
+
+        /// <summary>
+        /// Returns the SNAPPacket inside of the Packet p or null if
+        /// there is no encapsulated packet
+        /// </summary>
+        /// <param name="p">
+        /// A <see cref="Packet"/>
+        /// </param>
+        /// <returns>
+        /// A <see cref="SNAPPacket"/>
+        /// </returns>
+        [Obsolete("Use Packet.Extract() instead")]
+        public static SNAPPacket GetEncapsulated(Packet p)
+        {
+            log.Debug("");
+
+            if (p is SNAPPacket)
+            {
+                return (SNAPPacket)p;
+            }
+
+            return null;
+        }
+
+        /// <summary> Fetch ascii escape sequence of the color associated with this packet type.</summary>
+        public override System.String Color
+        {
+            get
+            {
+                return AnsiEscapeSequences.DarkGray;
+            }
+        }
+
+        /// <summary cref="Packet.ToString(StringOutputType)" />
+        public override string ToString(StringOutputType outputFormat)
+        {
+            var buffer = new StringBuilder();
+            string color = "";
+            string colorEscape = "";
+
+            if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
+            {
+                color = Color;
+                colorEscape = AnsiEscapeSequences.Reset;
+            }
+
+            if(outputFormat == StringOutputType.Normal || outputFormat == StringOutputType.Colored)
+            {
+                // build the output string
+                buffer.AppendFormat("{0}[LLC/SNAP Packet: DSAP={2}, SSAP={3}, Control={4}, OrgCode={5}, EtherType={6}]{1}",
+                    color,
+                    colorEscape,
+                    DSAP,
+                    SSAP,
+                    ControlField,
+                    OrgCode,
+                    EtherType.ToString());
+            }
+
+            if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
+            {
+                // collect the properties and their value
+                Dictionary<string,string> properties = new Dictionary<string,string>();
+                properties.Add("DSAP", DSAP.ToString());
+                properties.Add("SSAP", SSAP.ToString());
+                properties.Add("control", ControlField.ToString());
+                properties.Add("OrganizationCode", OrgCode.ToString());
+                properties.Add("EtherType", EtherType.ToString());
+
+                // calculate the padding needed to right-justify the property names
+                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+
+                // build the output string
+                buffer.AppendLine("LLC/SNAP:  ******* LLC/SNAP - \"LLC/SNAP\" - offset=? length=" + TotalPacketLength);
+                buffer.AppendLine("SNAP:");
+                foreach(var property in properties)
+                {
+                    buffer.AppendLine("SNAP: " + property.Key.PadLeft(padLength) + " = " + property.Value);
+                }
+                buffer.AppendLine("SNAP:");
+            }
+
+            // append the base output
+            buffer.Append(base.ToString(outputFormat));
+
+            return buffer.ToString();
+        }
+
+        /// <summary>
+        /// Generate a random EthernetPacket
+        /// TODO: could improve this routine to set a random payload as well
+        /// </summary>
+        /// <returns>
+        /// A <see cref="EthernetPacket"/>
+        /// </returns>
+        public static SNAPPacket RandomPacket()
+        {
+            var rnd = new Random();
+
+            return new SNAPPacket((byte)rnd.Next(256), (byte)rnd.Next(256), (byte)rnd.Next(256), rnd.Next(65535), EthernetPacketType.IpV4);
+        }
+    }
+}

--- a/PacketDotNet/SNAPPacket.cs
+++ b/PacketDotNet/SNAPPacket.cs
@@ -357,11 +357,11 @@ namespace PacketDotNet
         }
 
         /// <summary>
-        /// Generate a random EthernetPacket
+        /// Generate a random SNAPPacket
         /// TODO: could improve this routine to set a random payload as well
         /// </summary>
         /// <returns>
-        /// A <see cref="EthernetPacket"/>
+        /// A <see cref="SNAPPacket"/>
         /// </returns>
         public static SNAPPacket RandomPacket()
         {


### PR DESCRIPTION
LLC/SNAP packet definition is added. This makes it possible to parse payload packets captured over 802.11 radiotap packets from networks that are not encrypted.

You can find more information about the structure of the packet here:
https://en.wikipedia.org/wiki/Subnetwork_Access_Protocol
http://libtins.github.io/tutorial/802.11/

The attached zip file has a pcap trace which can be used to test the changes.

[80211_radiotap_icmp_test.zip](https://github.com/chmorgan/packetnet/files/105714/80211_radiotap_icmp_test.zip)
