### PR TITLE
Changes to support Raw IP packets

### DIFF
--- a/PacketDotNet/Packet.cs
+++ b/PacketDotNet/Packet.cs
@@ -320,6 +320,9 @@ namespace PacketDotNet
             case LinkLayers.PerPacketInformation:
                 p = new Ieee80211.PpiPacket(bas);
                 break;
+            case LinkLayers.Raw:
+                p = new RawIPPacket(bas);
+                break;
             default:
                 throw new System.NotImplementedException("LinkLayer of " + LinkLayer + " is not implemented");
             }

--- a/PacketDotNet/PacketDotNet.csproj
+++ b/PacketDotNet/PacketDotNet.csproj
@@ -94,6 +94,8 @@
     <Compile Include="OSPFv2Packet.cs" />
     <Compile Include="OSPFVersion.cs" />
     <Compile Include="Packet.cs" />
+    <Compile Include="RawIPPacket.cs" />
+    <Compile Include="RawIPPacketProtocol.cs" />
     <Compile Include="SessionPacket.cs" />
     <Compile Include="TcpPacket.cs" />
     <Compile Include="UdpPacket.cs" />

--- a/PacketDotNet/RawIPPacket.cs
+++ b/PacketDotNet/RawIPPacket.cs
@@ -1,0 +1,148 @@
+﻿/*
+This file is part of PacketDotNet
+
+PacketDotNet is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PacketDotNet is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ *  Copyright 2016 Cameron Elliott <cameron@cameronelliott.com>
+ */
+using System;
+using System.Collections.Generic;
+using System.Text;
+using PacketDotNet.Utils;
+using MiscUtil.Conversion;
+
+namespace PacketDotNet
+{
+    /// <summary>
+    /// Raw IP packet
+    /// See http://www.tcpdump.org/linktypes.html look for LINKTYPE_RAW or DLT_RAW
+    /// </summary>
+    [Serializable]
+    public class RawIPPacket : Packet
+    {
+
+
+        /// <summary>
+        /// </summary>
+        public RawIPPacketProtocol Protocol;
+       
+
+      
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="bas">
+        /// A <see cref="ByteArraySegment"/>
+        /// </param>
+        public RawIPPacket(ByteArraySegment bas)
+        {
+
+            Protocol = (RawIPPacketProtocol)(bas.Bytes[0] >> 4);
+
+            // slice off the header portion as our header
+            //header = new ByteArraySegment(bas);
+            //header.Length = PPPFields.HeaderLength;
+
+            // parse the encapsulated bytes
+            payloadPacketOrData = ParseEncapsulatedBytes(header, Protocol);
+        }
+
+        internal static PacketOrByteArraySegment ParseEncapsulatedBytes(ByteArraySegment Header,
+                                                                        RawIPPacketProtocol Protocol)
+        {
+            // slice off the payload
+            var payload = Header.EncapsulatedBytes();
+
+
+            var payloadPacketOrData = new PacketOrByteArraySegment();
+
+            switch (Protocol)
+            {
+                case RawIPPacketProtocol.IPv4:
+                    payloadPacketOrData.ThePacket = new IPv4Packet(payload);
+                    break;
+                case RawIPPacketProtocol.IPv6:
+                    payloadPacketOrData.ThePacket = new IPv6Packet(payload);
+                    break;
+                default:
+                    throw new System.NotImplementedException("Protocol of " + Protocol + " is not implemented");
+            }
+
+            return payloadPacketOrData;
+        }
+
+        /// <summary> Fetch ascii escape sequence of the color associated with this packet type.</summary>
+        public override System.String Color
+        {
+            get
+            {
+                return AnsiEscapeSequences.DarkGray;
+            }
+        }
+      
+
+        /// <summary cref="Packet.ToString(StringOutputType)" />
+        public override string ToString(StringOutputType outputFormat)
+        {
+            var buffer = new StringBuilder();
+            string color = "";
+            string colorEscape = "";
+
+            if (outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
+            {
+                color = Color;
+                colorEscape = AnsiEscapeSequences.Reset;
+            }
+
+            if (outputFormat == StringOutputType.Normal || outputFormat == StringOutputType.Colored)
+            {
+                // build the output string
+                buffer.AppendFormat("{0}[RawPacket: Protocol={2}]{1}",
+                    color,
+                    colorEscape,
+                    Protocol);
+            }
+
+            if (outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
+            {
+                // collect the properties and their value
+                Dictionary<string, string> properties = new Dictionary<string, string>();
+                properties.Add("protocol", Protocol.ToString() + " (0x" + Protocol.ToString("x") + ")");
+
+                // calculate the padding needed to right-justify the property names
+                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+
+                // build the output string
+                buffer.AppendLine("Raw:  ******* Raw - \"Raw IP Packet\" - offset=? length=" + TotalPacketLength);
+                buffer.AppendLine("Raw:");
+                foreach (var property in properties)
+                {
+                    buffer.AppendLine("Raw: " + property.Key.PadLeft(padLength) + " = " + property.Value);
+                }
+                buffer.AppendLine("Raw:");
+            }
+
+            // append the base output
+            buffer.Append(base.ToString(outputFormat));
+
+            return buffer.ToString();
+        }
+
+        
+    }
+}
+

--- a/PacketDotNet/RawIPPacketProtocol.cs
+++ b/PacketDotNet/RawIPPacketProtocol.cs
@@ -1,0 +1,38 @@
+﻿/*
+This file is part of PacketDotNet
+
+PacketDotNet is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PacketDotNet is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
+ *  Copyright 2010 Cameron Elliott <cameron/at/cameronelliott/dot/com>
+ *  
+ */
+using System;
+namespace PacketDotNet
+{
+    /// <summary>
+    /// Indicates the protocol encapsulated by the PPP packet
+    /// See http://www.iana.org/assignments/ppp-numbers
+    /// </summary>
+    public enum RawIPPacketProtocol : ushort
+    {
+        /// <summary> IPv4 </summary>
+        IPv4 = 4,
+
+        /// <summary> IPv6 </summary>
+        IPv6 = 6,
+    }
+}
+


### PR DESCRIPTION
Raw IP packets are IPv4 and IPv6 directly inside the raw libpcap packet, the first
byte of the Raw IP packet is the first byte of the IPv4 or IPv6 packet.

This link provides a little information: http://www.tcpdump.org/linktypes.html
[Search for LINKTYPE_RAW]

This is the file format you get when you use Rawcap.exe to capture packets on the loopback interface.
More: http://www.netresec.com/?page=RawCap
[Winpcap cannot normally capture off of the loopback interface, so this is a nice tool to capture loopback packets, and with the added support for Raw linklayer, you can now parse these with Packetnet]

It is quite possible this is the link layer used by Wireshark and other tools on Linux when capturing from the loopback interface, although they can use LinuxSLL as an option.