### PR TITLE
Change all types to CLR

### DIFF
--- a/Examples/CapturingAndParsingPackets/Main.cs
+++ b/Examples/CapturingAndParsingPackets/Main.cs
@@ -7,12 +7,12 @@ namespace CapturingAndParsingPackets
     class MainClass
     {
         // used to stop the capture loop
-        private static bool stopCapturing = false;
+        private static Boolean stopCapturing = false;
 
-        public static void Main(string[] args)
+        public static void Main(String[] args)
         {
             // Print SharpPcap version
-            string ver = SharpPcap.Version.VersionString;
+            String ver = SharpPcap.Version.VersionString;
             Console.WriteLine("PacketDotNet example using SharpPcap {0}", ver);
 
             // Retrieve the device list
@@ -30,7 +30,7 @@ namespace CapturingAndParsingPackets
             Console.WriteLine("----------------------------------------------------");
             Console.WriteLine();
 
-            int i = 0;
+            Int32 i = 0;
 
             // Print out the devices
             foreach(var dev in devices)
@@ -42,7 +42,7 @@ namespace CapturingAndParsingPackets
 
             Console.WriteLine();
             Console.Write("-- Please choose a device to capture: ");
-            i = int.Parse( Console.ReadLine() );
+            i = Int32.Parse( Console.ReadLine() );
 
             // Register a cancle handler that lets us break out of our capture loop
             Console.CancelKeyPress += HandleCancelKeyPress;
@@ -50,7 +50,7 @@ namespace CapturingAndParsingPackets
             var device = devices[i];
 
             // Open the device for capturing
-            int readTimeoutMilliseconds = 1000;
+            Int32 readTimeoutMilliseconds = 1000;
             device.Open(DeviceMode.Promiscuous, readTimeoutMilliseconds);
 
             Console.WriteLine();
@@ -86,7 +86,7 @@ namespace CapturingAndParsingPackets
             device.Close();
         }
 
-        static void HandleCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        static void HandleCancelKeyPress(Object sender, ConsoleCancelEventArgs e)
         {
             Console.WriteLine("-- Stopping capture");
             stopCapturing = true;

--- a/Examples/CapturingAndParsingWiFiPackets/Main.cs
+++ b/Examples/CapturingAndParsingWiFiPackets/Main.cs
@@ -12,12 +12,12 @@ namespace CapturingAndParsingWiFiPackets
     class MainClass
     {
         // used to stop the capture loop
-        private static bool stopCapturing = false;
+        private static Boolean stopCapturing = false;
 
-        public static void Main (string[] args)
+        public static void Main (String[] args)
         {
             // Print SharpPcap version
-            string ver = SharpPcap.Version.VersionString;
+            String ver = SharpPcap.Version.VersionString;
             Console.WriteLine ("PacketDotNet example using SharpPcap {0}", ver);
 
             // Retrieve the device list
@@ -35,7 +35,7 @@ namespace CapturingAndParsingWiFiPackets
             Console.WriteLine ("----------------------------------------------------");
             Console.WriteLine ();
 
-            int i = 0;
+            Int32 i = 0;
 
             // Print out the devices
             foreach (var dev in devices)
@@ -47,7 +47,7 @@ namespace CapturingAndParsingWiFiPackets
 
             Console.WriteLine ();
             Console.Write ("-- Please choose a device to capture: ");
-            i = int.Parse (Console.ReadLine ());
+            i = Int32.Parse (Console.ReadLine ());
 
             // Register a cancle handler that lets us break out of our capture loop
             // since we currently need to synchronously receive packets in order to get
@@ -59,7 +59,7 @@ namespace CapturingAndParsingWiFiPackets
             var device = (AirPcapDevice)devices [i];
 
             // Open the device for capturing
-            int readTimeoutMilliseconds = 1000;
+            Int32 readTimeoutMilliseconds = 1000;
             device.Open (DeviceMode.Promiscuous, readTimeoutMilliseconds);
             device.FcsValidation = AirPcapValidationType.ACCEPT_CORRECT_FRAMES;
 
@@ -102,7 +102,7 @@ namespace CapturingAndParsingWiFiPackets
             device.Close ();
         }
 
-        static void HandleCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        static void HandleCancelKeyPress(Object sender, ConsoleCancelEventArgs e)
         {
             Console.WriteLine("-- Stopping capture");
             stopCapturing = true;

--- a/Examples/ConstructingPackets/Main.cs
+++ b/Examples/ConstructingPackets/Main.cs
@@ -9,10 +9,10 @@ namespace ConstructingPackets
     /// </summary>
     class MainClass
     {
-        public static void Main(string[] args)
+        public static void Main(String[] args)
         {
-            ushort tcpSourcePort = 123;
-            ushort tcpDestinationPort = 321;
+            UInt16 tcpSourcePort = 123;
+            UInt16 tcpDestinationPort = 321;
             var tcpPacket = new TcpPacket(tcpSourcePort, tcpDestinationPort);
 
             var ipSourceAddress = System.Net.IPAddress.Parse("192.168.1.1");

--- a/Examples/ConstructingWiFiPackets/Program.cs
+++ b/Examples/ConstructingWiFiPackets/Program.cs
@@ -13,12 +13,12 @@ namespace ConstructingWiFiPackets
     class Program
     {
         private static PhysicalAddress adapterAddress;
-        private static bool stopCapturing = false;
+        private static Boolean stopCapturing = false;
         
-        static void Main(string[] args)
+        static void Main(String[] args)
         {
             // Print SharpPcap version
-            string ver = SharpPcap.Version.VersionString;
+            String ver = SharpPcap.Version.VersionString;
             Console.WriteLine("PacketDotNet example using SharpPcap {0}", ver);
 
             // Retrieve the device list
@@ -36,7 +36,7 @@ namespace ConstructingWiFiPackets
             Console.WriteLine("----------------------------------------------------");
             Console.WriteLine();
 
-            int i = 0;
+            Int32 i = 0;
 
             // Print out the devices
             foreach (var dev in devices)
@@ -48,7 +48,7 @@ namespace ConstructingWiFiPackets
 
             Console.WriteLine();
             Console.Write("-- Please choose a device to capture: ");
-            i = int.Parse(Console.ReadLine());
+            i = Int32.Parse(Console.ReadLine());
 
             // Register a cancle handler that lets us break out of our capture loop
             // since we currently need to synchronously receive packets in order to get
@@ -77,9 +77,9 @@ namespace ConstructingWiFiPackets
             System.Text.ASCIIEncoding encoding = new System.Text.ASCIIEncoding();
             InformationElement ssidIe = new InformationElement(InformationElement.ElementId.ServiceSetIdentity, encoding.GetBytes(ssid));
             InformationElement supportedRatesIe = new InformationElement(InformationElement.ElementId.SupportedRates,
-                new byte[] { 0x02, 0x04, 0x0b, 0x16, 0x0c, 0x12, 0x18, 0x24 });
+                new Byte[] { 0x02, 0x04, 0x0b, 0x16, 0x0c, 0x12, 0x18, 0x24 });
             InformationElement extendedSupportedRatesIe = new InformationElement(InformationElement.ElementId.ExtendedSupportedRates,
-                new byte[] { 0x30, 0x48, 0x60, 0x6c });
+                new Byte[] { 0x30, 0x48, 0x60, 0x6c });
             //Create a broadcast probe
             ProbeRequestFrame probe = new ProbeRequestFrame(device.MacAddress,
                                                             broadcastAddress,
@@ -118,7 +118,7 @@ namespace ConstructingWiFiPackets
             }
         }
 
-        static void device_OnPacketArrival(object sender, CaptureEventArgs e)
+        static void device_OnPacketArrival(Object sender, CaptureEventArgs e)
         {
             MacFrame p = Packet.ParsePacket(e.Packet.LinkLayerType, e.Packet.Data) as MacFrame;
 
@@ -133,7 +133,7 @@ namespace ConstructingWiFiPackets
             }
         }
 
-        static void HandleCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        static void HandleCancelKeyPress(Object sender, ConsoleCancelEventArgs e)
         {
             Console.WriteLine("-- Stopping capture");
             stopCapturing = true;

--- a/PacketDotNet/ARPFields.cs
+++ b/PacketDotNet/ARPFields.cs
@@ -17,6 +17,9 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary> IP protocol field encoding information.
@@ -28,41 +31,41 @@ namespace PacketDotNet
     public class ARPFields
     {
         /// <summary> Type code for ethernet addresses.</summary>
-        public readonly static int EthernetProtocolType = 0x0001;
+        public readonly static Int32 EthernetProtocolType = 0x0001;
         /// <summary> Type code for MAC addresses.</summary>
-        public readonly static int IPv4ProtocolType = 0x0800;
+        public readonly static Int32 IPv4ProtocolType = 0x0800;
 
         /// <summary> Operation type length in bytes.</summary>
-        public readonly static int OperationLength = 2;
+        public readonly static Int32 OperationLength = 2;
         /// <summary>
         /// The length of the address type fields in bytes,
         /// eg. the length of hardware type or protocol type
         /// </summary>
-        public readonly static int AddressTypeLength = 2;
+        public readonly static Int32 AddressTypeLength = 2;
         /// <summary>
         /// The length of the address length fields in bytes.
         /// </summary>
-        public readonly static int AddressLengthLength = 1;
+        public readonly static Int32 AddressLengthLength = 1;
         /// <summary> Position of the hardware address type.</summary>
-        public readonly static int HardwareAddressTypePosition = 0;
+        public readonly static Int32 HardwareAddressTypePosition = 0;
         /// <summary> Position of the protocol address type.</summary>
-        public readonly static int ProtocolAddressTypePosition;
+        public readonly static Int32 ProtocolAddressTypePosition;
         /// <summary> Position of the hardware address length.</summary>
-        public readonly static int HardwareAddressLengthPosition;
+        public readonly static Int32 HardwareAddressLengthPosition;
         /// <summary> Position of the protocol address length.</summary>
-        public readonly static int ProtocolAddressLengthPosition;
+        public readonly static Int32 ProtocolAddressLengthPosition;
         /// <summary> Position of the operation type.</summary>
-        public readonly static int OperationPosition;
+        public readonly static Int32 OperationPosition;
         /// <summary> Position of the sender hardware address.</summary>
-        public readonly static int SenderHardwareAddressPosition;
+        public readonly static Int32 SenderHardwareAddressPosition;
         /// <summary> Position of the sender protocol address.</summary>
-        public readonly static int SenderProtocolAddressPosition;
+        public readonly static Int32 SenderProtocolAddressPosition;
         /// <summary> Position of the target hardware address.</summary>
-        public readonly static int TargetHardwareAddressPosition;
+        public readonly static Int32 TargetHardwareAddressPosition;
         /// <summary> Position of the target protocol address.</summary>
-        public readonly static int TargetProtocolAddressPosition;
+        public readonly static Int32 TargetProtocolAddressPosition;
         /// <summary> Total length in bytes of an ARP header.</summary>
-        public readonly static int HeaderLength; // == 28
+        public readonly static Int32 HeaderLength; // == 28
 
         static ARPFields()
         {

--- a/PacketDotNet/ARPPacket.cs
+++ b/PacketDotNet/ARPPacket.cs
@@ -85,7 +85,7 @@ namespace PacketDotNet
         /// <value>
         /// Hardware address length field
         /// </value>
-        virtual public int HardwareAddressLength
+        virtual public Int32 HardwareAddressLength
         {
             get
             {
@@ -94,14 +94,14 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + ARPFields.HardwareAddressLengthPosition] = (byte)value;
+                header.Bytes[header.Offset + ARPFields.HardwareAddressLengthPosition] = (Byte)value;
             }
         }
 
         /// <value>
         /// Protocol address length field
         /// </value>
-        virtual public int ProtocolAddressLength
+        virtual public Int32 ProtocolAddressLength
         {
             get
             {
@@ -110,7 +110,7 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + ARPFields.ProtocolAddressLengthPosition] = (byte)value;
+                header.Bytes[header.Offset + ARPFields.ProtocolAddressLengthPosition] = (Byte)value;
             }
         }
 
@@ -155,7 +155,7 @@ namespace PacketDotNet
                 if (value.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
                     throw new System.InvalidOperationException("Family != IPv4, ARP is used for IPv4, NDP for IPv6");
 
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + ARPFields.SenderProtocolAddressPosition,
                            address.Length);
@@ -180,7 +180,7 @@ namespace PacketDotNet
                 if (value.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
                     throw new System.InvalidOperationException("Family != IPv4, ARP is used for IPv4, NDP for IPv6");
 
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + ARPFields.TargetProtocolAddressPosition,
                            address.Length);
@@ -196,7 +196,7 @@ namespace PacketDotNet
             {
                 //FIXME: this code is broken because it assumes that the address position is
                 // a fixed position
-                byte[] hwAddress = new byte[HardwareAddressLength];
+                Byte[] hwAddress = new Byte[HardwareAddressLength];
                 Array.Copy(header.Bytes, header.Offset + ARPFields.SenderHardwareAddressPosition,
                            hwAddress, 0, hwAddress.Length);
                 return new PhysicalAddress(hwAddress);
@@ -204,7 +204,7 @@ namespace PacketDotNet
 
             set
             {
-                byte[] hwAddress = value.GetAddressBytes();
+                Byte[] hwAddress = value.GetAddressBytes();
 
                 // for now we only support ethernet addresses even though the arp protocol
                 // makes provisions for varying length addresses
@@ -231,7 +231,7 @@ namespace PacketDotNet
             {
                 //FIXME: this code is broken because it assumes that the address position is
                 // a fixed position
-                byte[] hwAddress = new byte[HardwareAddressLength];
+                Byte[] hwAddress = new Byte[HardwareAddressLength];
                 Array.Copy(header.Bytes, header.Offset + ARPFields.TargetHardwareAddressPosition,
                            hwAddress, 0,
                            hwAddress.Length);
@@ -239,7 +239,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] hwAddress = value.GetAddressBytes();
+                Byte[] hwAddress = value.GetAddressBytes();
 
                 // for now we only support ethernet addresses even though the arp protocol
                 // makes provisions for varying length addresses
@@ -293,9 +293,9 @@ namespace PacketDotNet
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int length = ARPFields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = ARPFields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             this.Operation = Operation;
@@ -328,11 +328,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -356,7 +356,7 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("hardware type", HardwareAddressType.ToString() + " (0x" + HardwareAddressType.ToString("x") + ")");
                 properties.Add("protocol type", ProtocolAddressType.ToString() + " (0x" + ProtocolAddressType.ToString("x") + ")");
                 properties.Add("operation", Operation.ToString() + " (0x" + Operation.ToString("x") + ")");
@@ -366,7 +366,7 @@ namespace PacketDotNet
                 properties.Add("destination protocol address", TargetProtocolAddress.ToString());
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("ARP:  ******* ARP - \"Address Resolution Protocol\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/DrdaDDMFields.cs
+++ b/PacketDotNet/DrdaDDMFields.cs
@@ -31,77 +31,77 @@ namespace PacketDotNet
         /// <summary>
         /// Length of the Length number in bytes.
         /// </summary>
-        public readonly static int LengthLength = 2;
+        public readonly static Int32 LengthLength = 2;
 
         /// <summary>
         /// Length of the Magic field in bytes.
         /// </summary>
-        public readonly static int MagicLength = 1;
+        public readonly static Int32 MagicLength = 1;
 
         /// <summary>
         /// Length of the Format field in bytes.
         /// </summary>
-        public readonly static int FormatLength = 1;
+        public readonly static Int32 FormatLength = 1;
 
         /// <summary>
         /// Length of the CorrelId field in bytes.
         /// </summary>
-        public readonly static int CorrelIdLength = 2;
+        public readonly static Int32 CorrelIdLength = 2;
 
         /// <summary>
         /// Length of the Length2 number in bytes.
         /// </summary>
-        public readonly static int Length2Length = 2;
+        public readonly static Int32 Length2Length = 2;
 
         /// <summary>
         /// Length of the Code Point field in bytes.
         /// </summary>
-        public readonly static int CodePointLength = 2;
+        public readonly static Int32 CodePointLength = 2;
 
         /// <summary>
         /// Position of the Length field
         /// </summary>
-        public readonly static int LengthPosition = 0;
+        public readonly static Int32 LengthPosition = 0;
 
         /// <summary>
         /// Position of the Magic field
         /// </summary>
-        public readonly static int MagicPosition;
+        public readonly static Int32 MagicPosition;
 
         /// <summary>
         /// Position of the Format field
         /// </summary>
-        public readonly static int FormatPosition;
+        public readonly static Int32 FormatPosition;
 
         /// <summary>
         /// Position of the CorrlId field
         /// </summary>
-        public readonly static int CorrelIdPosition;
+        public readonly static Int32 CorrelIdPosition;
 
         /// <summary>
         /// Position of the Length2 field
         /// </summary>
-        public readonly static int Length2Position;
+        public readonly static Int32 Length2Position;
 
         /// <summary>
         /// Position of the Code Point field
         /// </summary>
-        public readonly static int CodePointPosition;
+        public readonly static Int32 CodePointPosition;
 
         /// <summary>
         /// Total Length for DDM Head
         /// </summary>
-        public readonly static int DDMHeadTotalLength;
+        public readonly static Int32 DDMHeadTotalLength;
 
         /// <summary>
         /// Length of the Parameter Length number in bytes.
         /// </summary>
-        public readonly static int ParameterLengthLength = 2;
+        public readonly static Int32 ParameterLengthLength = 2;
 
         /// <summary>
         /// Length of the Parameter Code Point field in bytes.
         /// </summary>
-        public readonly static int ParameterCodePointLength = 2;
+        public readonly static Int32 ParameterCodePointLength = 2;
 
         static DrdaDDMFields()
         {

--- a/PacketDotNet/DrdaDDMPacket.cs
+++ b/PacketDotNet/DrdaDDMPacket.cs
@@ -46,7 +46,7 @@ namespace PacketDotNet
         /// <summary>
         /// The Length field
         /// </summary>
-        public ushort Length
+        public UInt16 Length
         {
             get
             {
@@ -57,7 +57,7 @@ namespace PacketDotNet
         /// <summary>
         /// The Magic field
         /// </summary>
-        public byte Magic
+        public Byte Magic
         {
             get
             {
@@ -68,7 +68,7 @@ namespace PacketDotNet
         /// <summary>
         /// The Format field
         /// </summary>
-        public byte Format
+        public Byte Format
         {
             get
             {
@@ -79,7 +79,7 @@ namespace PacketDotNet
         /// <summary>
         /// The CorrelId field
         /// </summary>
-        public ushort CorrelId
+        public UInt16 CorrelId
         {
             get
             {
@@ -90,7 +90,7 @@ namespace PacketDotNet
         /// <summary>
         /// The Length2 field
         /// </summary>
-        public ushort Length2
+        public UInt16 Length2
         {
             get
             {
@@ -124,7 +124,7 @@ namespace PacketDotNet
                 var ddmTotalLength = this.Length;
                 while (offset < header.Offset+ ddmTotalLength)
                 {
-                    int length = BigEndianBitConverter.Big.ToUInt16(header.Bytes, offset);
+                    Int32 length = BigEndianBitConverter.Big.ToUInt16(header.Bytes, offset);
                     if (length == 0)
                     {
                         length = header.Offset + ddmTotalLength - offset;
@@ -183,11 +183,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if (outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {

--- a/PacketDotNet/DrdaDDMParameter.cs
+++ b/PacketDotNet/DrdaDDMParameter.cs
@@ -29,7 +29,7 @@ namespace PacketDotNet
         /// <summary>
         /// The Length field
         /// </summary>
-        public int Length { set; get; }
+        public Int32 Length { set; get; }
 
         /// <summary>
         /// The Drda Code Point Type field
@@ -39,6 +39,6 @@ namespace PacketDotNet
         /// <summary>
         /// The Other Data field
         /// </summary>
-        public string Data { set; get; }
+        public String Data { set; get; }
     }
 }

--- a/PacketDotNet/DrdaPacket.cs
+++ b/PacketDotNet/DrdaPacket.cs
@@ -58,10 +58,10 @@ namespace PacketDotNet
                     ddmList = new List<DrdaDDMPacket>();
                 }
                 if (ddmList.Count > 0) return this.ddmList;
-                int startOffset = header.Offset;
+                Int32 startOffset = header.Offset;
                 while (startOffset < header.BytesLength)
                 {
-                    ushort length = BigEndianBitConverter.Big.ToUInt16(header.Bytes, startOffset);
+                    UInt16 length = BigEndianBitConverter.Big.ToUInt16(header.Bytes, startOffset);
                     if (startOffset + length <= header.BytesLength)
                     {
                         var ddmBas = new ByteArraySegment(header.Bytes, startOffset, length);
@@ -107,7 +107,7 @@ namespace PacketDotNet
         /// </summary>
         /// <param name="outputFormat"></param>
         /// <returns></returns>
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             return base.ToString(outputFormat);
         }

--- a/PacketDotNet/EthernetFields.cs
+++ b/PacketDotNet/EthernetFields.cs
@@ -27,19 +27,19 @@ namespace PacketDotNet
     public class EthernetFields
     {
         /// <summary> Width of the ethernet type code in bytes.</summary>
-        public readonly static int TypeLength = 2;
+        public readonly static Int32 TypeLength = 2;
 
         /// <summary> Position of the destination MAC address within the ethernet header.</summary>
-        public readonly static int DestinationMacPosition = 0;
+        public readonly static Int32 DestinationMacPosition = 0;
 
         /// <summary> Position of the source MAC address within the ethernet header.</summary>
-        public readonly static int SourceMacPosition;
+        public readonly static Int32 SourceMacPosition;
 
         /// <summary> Position of the ethernet type field within the ethernet header.</summary>
-        public readonly static int TypePosition;
+        public readonly static Int32 TypePosition;
 
         /// <summary> Total length of an ethernet header in bytes.</summary>
-        public readonly static int HeaderLength; // == 14
+        public readonly static Int32 HeaderLength; // == 14
 
         static EthernetFields()
         {
@@ -51,6 +51,6 @@ namespace PacketDotNet
         /// <summary>
         /// size of an ethernet mac address in bytes
         /// </summary>
-        public readonly static int MacAddressLength = 6;
+        public readonly static Int32 MacAddressLength = 6;
     }
 }

--- a/PacketDotNet/EthernetPacket.cs
+++ b/PacketDotNet/EthernetPacket.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
 PacketDotNet is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
-﻿using System;
+ using System;
 using System.Collections.Generic;
 using System.Net.NetworkInformation;
 using System.Text;
@@ -88,7 +88,7 @@ namespace PacketDotNet
         {
             get
             {
-                byte[] hwAddress = new byte[EthernetFields.MacAddressLength];
+                Byte[] hwAddress = new Byte[EthernetFields.MacAddressLength];
                 Array.Copy(header.Bytes, header.Offset + EthernetFields.SourceMacPosition,
                            hwAddress, 0, hwAddress.Length);
                 return new PhysicalAddress(hwAddress);
@@ -96,7 +96,7 @@ namespace PacketDotNet
 
             set
             {
-                byte[] hwAddress = value.GetAddressBytes();
+                Byte[] hwAddress = value.GetAddressBytes();
                 if(hwAddress.Length != EthernetFields.MacAddressLength)
                 {
                     throw new System.InvalidOperationException("address length " + hwAddress.Length
@@ -114,7 +114,7 @@ namespace PacketDotNet
         {
             get
             {
-                byte[] hwAddress = new byte[EthernetFields.MacAddressLength];
+                Byte[] hwAddress = new Byte[EthernetFields.MacAddressLength];
                 Array.Copy(header.Bytes, header.Offset + EthernetFields.DestinationMacPosition,
                            hwAddress, 0, hwAddress.Length);
                 return new PhysicalAddress(hwAddress);
@@ -122,7 +122,7 @@ namespace PacketDotNet
 
             set
             {
-                byte[] hwAddress = value.GetAddressBytes();
+                Byte[] hwAddress = value.GetAddressBytes();
                 if(hwAddress.Length != EthernetFields.MacAddressLength)
                 {
                     throw new System.InvalidOperationException("address length " + hwAddress.Length
@@ -165,9 +165,9 @@ namespace PacketDotNet
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int length = EthernetFields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = EthernetFields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             // set the instance values
@@ -258,11 +258,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -284,13 +284,13 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("destination", HexPrinter.PrintMACAddress(DestinationHwAddress));
                 properties.Add("source", HexPrinter.PrintMACAddress(SourceHwAddress));
                 properties.Add("type", Type.ToString() + " (0x" + Type.ToString("x") + ")");
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("Eth:  ******* Ethernet - \"Ethernet\" - offset=? length=" + TotalPacketLength);
@@ -319,8 +319,8 @@ namespace PacketDotNet
         {
             var rnd = new Random();
 
-            byte[] srcPhysicalAddress = new byte[EthernetFields.MacAddressLength];
-            byte[] dstPhysicalAddress = new byte[EthernetFields.MacAddressLength];
+            Byte[] srcPhysicalAddress = new Byte[EthernetFields.MacAddressLength];
+            Byte[] dstPhysicalAddress = new Byte[EthernetFields.MacAddressLength];
 
             rnd.NextBytes(srcPhysicalAddress);
             rnd.NextBytes(dstPhysicalAddress);

--- a/PacketDotNet/GREFields.cs
+++ b/PacketDotNet/GREFields.cs
@@ -17,27 +17,30 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2018 Steven Haufe<haufes@hotmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary> GRE protocol field encoding information. </summary>
     public class GREFields
     {
         /// <summary> Length of the Flags in bytes.</summary>
-        public readonly static int FlagsLength = 2;
+        public readonly static Int32 FlagsLength = 2;
         /// <summary> Length of the Protocol in bytes.</summary>
-        public readonly static int ProtocolLength = 2;
+        public readonly static Int32 ProtocolLength = 2;
         /// <summary> Length of the Checksum in bytes (Optional).</summary>      
-        public readonly static int ChecksumLength = 2;
+        public readonly static Int32 ChecksumLength = 2;
         /// <summary> Length of the Reserved in bytes (Optional).</summary>
-        public readonly static int ReservedLength = 2;
+        public readonly static Int32 ReservedLength = 2;
         /// <summary> Length of the Key in bytes (Optional).</summary>
-        public readonly static int KeyLength = 4;
+        public readonly static Int32 KeyLength = 4;
         /// <summary> Length of the Sequence Number in bytes (Optional).</summary>
-        public readonly static int SequenceLength = 4;
+        public readonly static Int32 SequenceLength = 4;
         /// <summary> Position of the Protocol.</summary>
-        public readonly static int ProtocolPosition = 2;
+        public readonly static Int32 ProtocolPosition = 2;
         /// <summary> Position of the Checksum in bytes (Optional).</summary>      
-        public readonly static int ChecksumPosition = 2;
+        public readonly static Int32 ChecksumPosition = 2;
 
 
     }

--- a/PacketDotNet/GREPacket.cs
+++ b/PacketDotNet/GREPacket.cs
@@ -32,14 +32,14 @@ namespace PacketDotNet
     public class GREPacket : Packet
     {
 
-        virtual public bool HasCheckSum
+        virtual public Boolean HasCheckSum
         {
             get
             {
                 return 8 == (header.Bytes[header.Offset + 1] & 0x8);
             }
         }
-        virtual public bool HasReserved
+        virtual public Boolean HasReserved
         {
             get
             {
@@ -47,14 +47,14 @@ namespace PacketDotNet
             }
         }
 
-        virtual public bool HasKey
+        virtual public Boolean HasKey
         {
             get
             {
                 return 2 == (header.Bytes[header.Offset + 1] & 0x2);
             }
         }
-        virtual public bool HasSequence
+        virtual public Boolean HasSequence
         {
             get
             {
@@ -63,7 +63,7 @@ namespace PacketDotNet
         }
 
 
-        virtual public int Version
+        virtual public Int32 Version
         {
             get
             {
@@ -82,7 +82,7 @@ namespace PacketDotNet
 
 
         /// <summary> Fetch the GRE header checksum.</summary>
-        virtual public short Checksum
+        virtual public Int16 Checksum
         {
             get
             {
@@ -131,11 +131,11 @@ namespace PacketDotNet
         
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
             
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
@@ -156,7 +156,7 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("Protocol ", Protocol + " (0x" + Protocol.ToString("x") + ")");
             }
 

--- a/PacketDotNet/ICMPv4Fields.cs
+++ b/PacketDotNet/ICMPv4Fields.cs
@@ -17,6 +17,9 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary>
@@ -26,24 +29,24 @@ namespace PacketDotNet
     public class ICMPv4Fields
     {
         /// <summary> Length of the ICMP message type code in bytes.</summary>
-        public readonly static int TypeCodeLength = 2;
+        public readonly static Int32 TypeCodeLength = 2;
         /// <summary> Length of the ICMP header checksum in bytes.</summary>
-        public readonly static int ChecksumLength = 2;
+        public readonly static Int32 ChecksumLength = 2;
         /// <summary> Length of the ICMP ID field in bytes.</summary>
-        public readonly static int IDLength = 2;
+        public readonly static Int32 IDLength = 2;
         /// <summary> Length of the ICMP Sequence field in bytes </summary>
-        public readonly static int SequenceLength = 2;
+        public readonly static Int32 SequenceLength = 2;
 
         /// <summary> Position of the ICMP message type/code.</summary>
-        public readonly static int TypeCodePosition = 0;
+        public readonly static Int32 TypeCodePosition = 0;
         /// <summary> Position of the ICMP header checksum.</summary>
-        public readonly static int ChecksumPosition;
+        public readonly static Int32 ChecksumPosition;
         /// <summary> Position of the ICMP ID field </summary>
-        public readonly static int IDPosition;
+        public readonly static Int32 IDPosition;
         /// <summary> Position of the Sequence field </summary>
-        public readonly static int SequencePosition;
+        public readonly static Int32 SequencePosition;
         /// <summary> Length in bytes of an ICMP header.</summary>
-        public readonly static int HeaderLength;
+        public readonly static Int32 HeaderLength;
 
         static ICMPv4Fields()
         {

--- a/PacketDotNet/ICMPv4Packet.cs
+++ b/PacketDotNet/ICMPv4Packet.cs
@@ -71,7 +71,7 @@ namespace PacketDotNet
         /// <value>
         /// Checksum value
         /// </value>
-        public ushort Checksum
+        public UInt16 Checksum
         {
             get
             {
@@ -91,7 +91,7 @@ namespace PacketDotNet
         /// <summary>
         /// ID field
         /// </summary>
-        public ushort ID
+        public UInt16 ID
         {
             get
             {
@@ -111,7 +111,7 @@ namespace PacketDotNet
         /// <summary>
         /// Sequence field
         /// </summary>
-        public ushort Sequence
+        public UInt16 Sequence
         {
             get
             {
@@ -130,7 +130,7 @@ namespace PacketDotNet
         /// <summary>
         /// Contents of the ICMP packet
         /// </summary>
-        public byte[] Data
+        public Byte[] Data
         {
             get
             {
@@ -186,11 +186,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -210,7 +210,7 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("type/code", TypeCode.ToString() + " (0x" + TypeCode.ToString("x") + ")");
                 // TODO: Implement checksum verification for ICMPv4
                 properties.Add("checksum", Checksum.ToString("x"));
@@ -218,7 +218,7 @@ namespace PacketDotNet
                 properties.Add("sequence number", Sequence + " (0x" + Sequence.ToString("x") + ")");
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("ICMP:  ******* ICMPv4 - \"Internet Control Message Protocol (Version 4)\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/ICMPv6Fields.cs
+++ b/PacketDotNet/ICMPv6Fields.cs
@@ -17,6 +17,9 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary>
@@ -26,19 +29,19 @@ namespace PacketDotNet
     public class ICMPv6Fields
     {
         /// <summary> Length of the ICMP message type code in bytes.</summary>
-        public readonly static int TypeLength = 1;
+        public readonly static Int32 TypeLength = 1;
         /// <summary> Length of the ICMP subcode in bytes.</summary>
-        public readonly static int CodeLength = 1;
+        public readonly static Int32 CodeLength = 1;
         /// <summary> Length of the ICMP header checksum in bytes.</summary>
-        public readonly static int ChecksumLength = 2;
+        public readonly static Int32 ChecksumLength = 2;
         /// <summary> Position of the ICMP message type.</summary>
-        public readonly static int TypePosition = 0;
+        public readonly static Int32 TypePosition = 0;
         /// <summary> Position of the ICMP message subcode.</summary>
-        public readonly static int CodePosition;
+        public readonly static Int32 CodePosition;
         /// <summary> Position of the ICMP header checksum.</summary>
-        public readonly static int ChecksumPosition;
+        public readonly static Int32 ChecksumPosition;
         /// <summary> Length in bytes of an ICMP header.</summary>
-        public readonly static int HeaderLength; // == 4
+        public readonly static Int32 HeaderLength; // == 4
 
         static ICMPv6Fields()
         {

--- a/PacketDotNet/ICMPv6Packet.cs
+++ b/PacketDotNet/ICMPv6Packet.cs
@@ -59,12 +59,12 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + ICMPv6Fields.TypePosition] = (byte)value;
+                header.Bytes[header.Offset + ICMPv6Fields.TypePosition] = (Byte)value;
             }
         }
 
         /// <summary> Fetch the ICMP code </summary>
-        virtual public byte Code
+        virtual public Byte Code
         {
             get
             {
@@ -73,14 +73,14 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + ICMPv6Fields.CodePosition] = (byte)value;
+                header.Bytes[header.Offset + ICMPv6Fields.CodePosition] = (Byte)value;
             }
         }
 
         /// <value>
         /// Checksum value
         /// </value>
-        public ushort Checksum
+        public UInt16 Checksum
         {
             get
             {
@@ -129,7 +129,7 @@ namespace PacketDotNet
         /// Used to prevent a recursive stack overflow
         /// when recalculating in UpdateCalculatedValues()
         /// </summary>
-        private bool skipUpdating = false;
+        private Boolean skipUpdating = false;
 
         /// <summary>
         /// Recalculate the checksum
@@ -153,7 +153,7 @@ namespace PacketDotNet
             var bytesToChecksum = ipv6Parent.AttachPseudoIPHeader(originalBytes);
 
             // calculate the one's complement sum of the tcp header
-            Checksum = (ushort)ChecksumUtils.OnesComplementSum(bytesToChecksum);
+            Checksum = (UInt16)ChecksumUtils.OnesComplementSum(bytesToChecksum);
 
             // clear the skip variable
             skipUpdating = false;
@@ -169,11 +169,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -194,15 +194,15 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
-                properties.Add("type", Type.ToString() + " (" + (int)Type + ")");
+                Dictionary<String,String> properties = new Dictionary<String,String>();
+                properties.Add("type", Type.ToString() + " (" + (Int32)Type + ")");
                 properties.Add("code", Code.ToString());
                 // TODO: Implement a checksum verification for ICMPv6
                 properties.Add("checksum", "0x" + Checksum.ToString("x"));
                 // TODO: Implement ICMPv6 Option fields here?
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("ICMP:  ******* ICMPv6 - \"Internet Control Message Protocol (Version 6)\"- offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/IGMPv2Fields.cs
+++ b/PacketDotNet/IGMPv2Fields.cs
@@ -17,29 +17,32 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary> IGMP protocol field encoding information. </summary>
     public class IGMPv2Fields
     {
         /// <summary> Length of the IGMP message type code in bytes.</summary>
-        public readonly static int TypeLength = 1;
+        public readonly static Int32 TypeLength = 1;
         /// <summary> Length of the IGMP max response code in bytes.</summary>
-        public readonly static int MaxResponseTimeLength = 1;
+        public readonly static Int32 MaxResponseTimeLength = 1;
         /// <summary> Length of the IGMP header checksum in bytes.</summary>
-        public readonly static int ChecksumLength = 2;
+        public readonly static Int32 ChecksumLength = 2;
         /// <summary> Length of group address in bytes.</summary>
-        public readonly static int GroupAddressLength;
+        public readonly static Int32 GroupAddressLength;
         /// <summary> Position of the IGMP message type.</summary>
-        public readonly static int TypePosition = 0;
+        public readonly static Int32 TypePosition = 0;
         /// <summary> Position of the IGMP max response code.</summary>
-        public readonly static int MaxResponseTimePosition;
+        public readonly static Int32 MaxResponseTimePosition;
         /// <summary> Position of the IGMP header checksum.</summary>
-        public readonly static int ChecksumPosition;
+        public readonly static Int32 ChecksumPosition;
         /// <summary> Position of the IGMP group address.</summary>
-        public readonly static int GroupAddressPosition;
+        public readonly static Int32 GroupAddressPosition;
         /// <summary> Length in bytes of an IGMP header.</summary>
-        public readonly static int HeaderLength; // 8
+        public readonly static Int32 HeaderLength; // 8
 
         static IGMPv2Fields()
         {

--- a/PacketDotNet/IGMPv2Packet.cs
+++ b/PacketDotNet/IGMPv2Packet.cs
@@ -44,12 +44,12 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + IGMPv2Fields.TypePosition] = (byte)value;
+                header.Bytes[header.Offset + IGMPv2Fields.TypePosition] = (Byte)value;
             }
         }
 
         /// <summary> Fetch the IGMP max response time.</summary>
-        virtual public byte MaxResponseTime
+        virtual public Byte MaxResponseTime
         {
             get
             {
@@ -63,7 +63,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Fetch the IGMP header checksum.</summary>
-        virtual public short Checksum
+        virtual public Int16 Checksum
         {
             get
             {
@@ -73,7 +73,7 @@ namespace PacketDotNet
 
             set
             {
-                byte[] theValue = BitConverter.GetBytes(value);
+                Byte[] theValue = BitConverter.GetBytes(value);
                 Array.Copy(theValue, 0, header.Bytes, (header.Offset + IGMPv2Fields.ChecksumPosition), 2);
             }
         }
@@ -133,11 +133,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -159,7 +159,7 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("type", Type + " (0x" + Type.ToString("x") + ")");
                 properties.Add("max response time", String.Format("{0:0.0}", MaxResponseTime / 10) + " sec (0x" + MaxResponseTime.ToString("x") + ")");
                 // TODO: Implement checksum validation for IGMPv2
@@ -167,7 +167,7 @@ namespace PacketDotNet
                 properties.Add("group address", GroupAddress.ToString());
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("IGMP:  ******* IGMPv2 - \"Internet Group Management Protocol (Version 2)\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/ILogInactive.cs
+++ b/PacketDotNet/ILogInactive.cs
@@ -38,211 +38,211 @@ namespace PacketDotNet
 #endif
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Debug (object message)
+        public void Debug (Object message)
         {
             throw new System.NotImplementedException();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Debug (object message, System.Exception exception)
+        public void Debug (Object message, System.Exception exception)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void DebugFormat(string format, params object[] args)
+        public void DebugFormat(String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void DebugFormat (System.IFormatProvider provider, string format, params object[] args)
+        public void DebugFormat (System.IFormatProvider provider, String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void DebugFormat (string format, object arg0)
+        public void DebugFormat (String format, Object arg0)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void DebugFormat (string format, object arg0, object arg1)
+        public void DebugFormat (String format, Object arg0, Object arg1)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void DebugFormat (string format, object arg0, object arg1, object arg2)
+        public void DebugFormat (String format, Object arg0, Object arg1, Object arg2)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Error (object message)
+        public void Error (Object message)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Error (object message, System.Exception exception)
+        public void Error (Object message, System.Exception exception)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void ErrorFormat(string format, params object[] args)
+        public void ErrorFormat(String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void ErrorFormat (System.IFormatProvider provider, string format, params object[] args)
+        public void ErrorFormat (System.IFormatProvider provider, String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void ErrorFormat (string format, object arg0)
+        public void ErrorFormat (String format, Object arg0)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void ErrorFormat (string format, object arg0, object arg1)
+        public void ErrorFormat (String format, Object arg0, Object arg1)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void ErrorFormat (string format, object arg0, object arg1, object arg2)
+        public void ErrorFormat (String format, Object arg0, Object arg1, Object arg2)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Fatal (object message)
+        public void Fatal (Object message)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Fatal (object message, System.Exception exception)
+        public void Fatal (Object message, System.Exception exception)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void FatalFormat(string format, params object[] args)
+        public void FatalFormat(String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void FatalFormat (System.IFormatProvider provider, string format, params object[] args)
+        public void FatalFormat (System.IFormatProvider provider, String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void FatalFormat (string format, object arg0)
+        public void FatalFormat (String format, Object arg0)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void FatalFormat (string format, object arg0, object arg1)
+        public void FatalFormat (String format, Object arg0, Object arg1)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void FatalFormat (string format, object arg0, object arg1, object arg2)
+        public void FatalFormat (String format, Object arg0, Object arg1, Object arg2)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Info (object message)
+        public void Info (Object message)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Info (object message, System.Exception exception)
+        public void Info (Object message, System.Exception exception)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void InfoFormat(string format, params object[] args)
+        public void InfoFormat(String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void InfoFormat (System.IFormatProvider provider, string format, params object[] args)
+        public void InfoFormat (System.IFormatProvider provider, String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void InfoFormat (string format, object arg0)
+        public void InfoFormat (String format, Object arg0)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void InfoFormat (string format, object arg0, object arg1)
+        public void InfoFormat (String format, Object arg0, Object arg1)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void InfoFormat (string format, object arg0, object arg1, object arg2)
+        public void InfoFormat (String format, Object arg0, Object arg1, Object arg2)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Warn (object message)
+        public void Warn (Object message)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void Warn (object message, System.Exception exception)
+        public void Warn (Object message, System.Exception exception)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void WarnFormat(string format, params object[] args)
+        public void WarnFormat(String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void WarnFormat (System.IFormatProvider provider, string format, params object[] args)
+        public void WarnFormat (System.IFormatProvider provider, String format, params Object[] args)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void WarnFormat (string format, object arg0)
+        public void WarnFormat (String format, Object arg0)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void WarnFormat (string format, object arg0, object arg1)
+        public void WarnFormat (String format, Object arg0, Object arg1)
         {
             throw new System.NotImplementedException ();
         }
 
         [System.Diagnostics.ConditionalAttribute("DEBUG")]
-        public void WarnFormat (string format, object arg0, object arg1, object arg2)
+        public void WarnFormat (String format, Object arg0, Object arg1, Object arg2)
         {
             throw new System.NotImplementedException ();
         }

--- a/PacketDotNet/IPv4Fields.cs
+++ b/PacketDotNet/IPv4Fields.cs
@@ -17,6 +17,9 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  * Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary>
@@ -25,68 +28,68 @@ namespace PacketDotNet
     public struct IPv4Fields
     {
         /// <summary> Width of the IP version and header length field in bytes.</summary>
-        public readonly static int VersionAndHeaderLengthLength = 1;
+        public readonly static Int32 VersionAndHeaderLengthLength = 1;
 
         /// <summary> Width of the Differentiated Services / Type of service field in bytes.</summary>
-        public readonly static int DifferentiatedServicesLength = 1;
+        public readonly static Int32 DifferentiatedServicesLength = 1;
 
         /// <summary> Width of the total length field in bytes.</summary>
-        public readonly static int TotalLengthLength = 2;
+        public readonly static Int32 TotalLengthLength = 2;
 
         /// <summary> Width of the ID field in bytes.</summary>
-        public readonly static int IdLength = 2;
+        public readonly static Int32 IdLength = 2;
 
         /// <summary> Width of the fragment offset bits and offset field in bytes.</summary>
-        public readonly static int FragmentOffsetAndFlagsLength = 2;
+        public readonly static Int32 FragmentOffsetAndFlagsLength = 2;
 
         /// <summary> Width of the TTL field in bytes.</summary>
-        public readonly static int TtlLength = 1;
+        public readonly static Int32 TtlLength = 1;
 
         /// <summary> Width of the IP protocol code in bytes.</summary>
-        public readonly static int ProtocolLength = 1;
+        public readonly static Int32 ProtocolLength = 1;
 
         /// <summary> Width of the IP checksum in bytes.</summary>
-        public readonly static int ChecksumLength = 2;
+        public readonly static Int32 ChecksumLength = 2;
 
         /// <summary> Position of the version code and header length within the IP header.</summary>
-        public readonly static int VersionAndHeaderLengthPosition = 0;
+        public readonly static Int32 VersionAndHeaderLengthPosition = 0;
 
         /// <summary> Position of the differentiated services value within the IP header.</summary>
-        public readonly static int DifferentiatedServicesPosition;
+        public readonly static Int32 DifferentiatedServicesPosition;
 
         /// <summary> Position of the header length within the IP header.</summary>
-        public readonly static int TotalLengthPosition;
+        public readonly static Int32 TotalLengthPosition;
 
         /// <summary> Position of the packet ID within the IP header.</summary>
-        public readonly static int IdPosition;
+        public readonly static Int32 IdPosition;
 
         /// <summary> Position of the flag bits and fragment offset within the IP header.</summary>
-        public readonly static int FragmentOffsetAndFlagsPosition;
+        public readonly static Int32 FragmentOffsetAndFlagsPosition;
 
         /// <summary> Position of the ttl within the IP header.</summary>
-        public readonly static int TtlPosition;
+        public readonly static Int32 TtlPosition;
 
         /// <summary>
         /// Position of the protocol used within the IP data
         /// </summary>
-        public readonly static int ProtocolPosition;
+        public readonly static Int32 ProtocolPosition;
 
         /// <summary> Position of the checksum within the IP header.</summary>
-        public readonly static int ChecksumPosition;
+        public readonly static Int32 ChecksumPosition;
 
         /// <summary> Position of the source IP address within the IP header.</summary>
-        public readonly static int SourcePosition;
+        public readonly static Int32 SourcePosition;
 
         /// <summary> Position of the destination IP address within a packet.</summary>
-        public readonly static int DestinationPosition;
+        public readonly static Int32 DestinationPosition;
 
         /// <summary> Length in bytes of an IP header, excluding options.</summary>
-        public readonly static int HeaderLength; // == 20
+        public readonly static Int32 HeaderLength; // == 20
 
         /// <summary>
         /// Number of bytes in an IPv4 address
         /// </summary>
-        public readonly static int AddressLength = 4;
+        public readonly static Int32 AddressLength = 4;
 
         static IPv4Fields()
         {

--- a/PacketDotNet/IPv4Packet.cs
+++ b/PacketDotNet/IPv4Packet.cs
@@ -46,7 +46,7 @@ namespace PacketDotNet
         /// <value>
         /// Number of bytes in the smallest valid ipv4 packet
         /// </value>
-        public const int HeaderMinimumLength = 20;
+        public const Int32 HeaderMinimumLength = 20;
 
         /// <summary> Type of service code constants for IP. Type of service describes
         /// how a packet should be handled.
@@ -65,11 +65,11 @@ namespace PacketDotNet
         public struct TypesOfService_Fields
         {
 #pragma warning disable 1591
-            public readonly static int MINIMIZE_DELAY = 0x10;
-            public readonly static int MAXIMIZE_THROUGHPUT = 0x08;
-            public readonly static int MAXIMIZE_RELIABILITY = 0x04;
-            public readonly static int MINIMIZE_MONETARY_COST = 0x02;
-            public readonly static int UNUSED = 0x01;
+            public readonly static Int32 MINIMIZE_DELAY = 0x10;
+            public readonly static Int32 MAXIMIZE_THROUGHPUT = 0x08;
+            public readonly static Int32 MAXIMIZE_RELIABILITY = 0x04;
+            public readonly static Int32 MINIMIZE_MONETARY_COST = 0x02;
+            public readonly static Int32 UNUSED = 0x01;
 #pragma warning restore 1591
         }
 
@@ -92,7 +92,7 @@ namespace PacketDotNet
                 var theByte = header.Bytes[header.Offset + IPv4Fields.VersionAndHeaderLengthPosition];
 
                 // mask in the version bits
-                theByte = (byte)((theByte & 0x0F) | (((byte)value << 4) & 0xF0));
+                theByte = (Byte)((theByte & 0x0F) | (((Byte)value << 4) & 0xF0));
 
                 // write back the modified value
                 header.Bytes[header.Offset + IPv4Fields.VersionAndHeaderLengthPosition] = theByte;
@@ -102,11 +102,11 @@ namespace PacketDotNet
         /// <value>
         /// Forwards compatibility IPv6.PayloadLength property
         /// </value>
-        public override ushort PayloadLength
+        public override UInt16 PayloadLength
         {
             get
             {
-                return (ushort)(TotalLength - (HeaderLength * 4));
+                return (UInt16)(TotalLength - (HeaderLength * 4));
             }
 
             set
@@ -122,7 +122,7 @@ namespace PacketDotNet
         /// </summary>
         /// <param name="length">The length of the IP header in 32-bit words.
         /// </param>
-        public override int HeaderLength
+        public override Int32 HeaderLength
         {
             get
             {
@@ -135,7 +135,7 @@ namespace PacketDotNet
                 var theByte = header.Bytes[header.Offset + IPv4Fields.VersionAndHeaderLengthPosition];
 
                 // mask in the header length bits
-                theByte = (byte)((theByte & 0xF0) | (((byte)value) & 0x0F));
+                theByte = (Byte)((theByte & 0xF0) | (((Byte)value) & 0x0F));
 
                 // write back the modified value
                 header.Bytes[header.Offset + IPv4Fields.VersionAndHeaderLengthPosition] = theByte;
@@ -147,7 +147,7 @@ namespace PacketDotNet
         /// increments by one each time a datagram is sent by a host.
         /// A 16-bit unsigned integer.
         /// </summary>
-        virtual public ushort Id
+        virtual public UInt16 Id
         {
             get
             {
@@ -168,7 +168,7 @@ namespace PacketDotNet
         /// The offset specifies a number of octets (i.e., bytes).
         /// A 13-bit unsigned integer.
         /// </summary>
-        virtual public int FragmentOffset
+        virtual public Int32 FragmentOffset
         {
             get
             {
@@ -186,7 +186,7 @@ namespace PacketDotNet
                                                                            header.Offset + IPv4Fields.FragmentOffsetAndFlagsPosition);
 
                 // mask the fragementation offset in
-                fragmentOffsetAndFlags = (short)((fragmentOffsetAndFlags & 0xE000) | (value & 0x1FFF));
+                fragmentOffsetAndFlags = (Int16)((fragmentOffsetAndFlags & 0xE000) | (value & 0x1FFF));
 
                 EndianBitConverter.Big.CopyBytes(fragmentOffsetAndFlags,
                                                  header.Bytes,
@@ -205,7 +205,7 @@ namespace PacketDotNet
 
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + IPv4Fields.SourcePosition,
                            address.Length);
@@ -223,7 +223,7 @@ namespace PacketDotNet
 
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + IPv4Fields.DestinationPosition,
                            address.Length);
@@ -231,7 +231,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Fetch the header checksum.</summary>
-        virtual public ushort Checksum
+        virtual public UInt16 Checksum
         {
             get
             {
@@ -249,7 +249,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Check if the IP packet is valid, checksum-wise.</summary>
-        virtual public bool ValidChecksum
+        virtual public Boolean ValidChecksum
         {
             get
             {
@@ -261,7 +261,7 @@ namespace PacketDotNet
         /// <summary>
         /// Check if the IP packet header is valid, checksum-wise.
         /// </summary>
-        public bool ValidIPChecksum
+        public Boolean ValidIPChecksum
         {
             get
             {
@@ -279,7 +279,7 @@ namespace PacketDotNet
                 {
                     var headerOnesSum = ChecksumUtils.OnesSum(Header);
                     log.DebugFormat(HexPrinter.GetString(Header, 0, Header.Length));
-                    const int expectedHeaderOnesSum = 0xffff;
+                    const Int32 expectedHeaderOnesSum = 0xffff;
                     var retval = (headerOnesSum == expectedHeaderOnesSum);
                     log.DebugFormat("headerOnesSum: {0}, expectedHeaderOnesSum {1}, returning {2}",
                                     headerOnesSum,
@@ -301,7 +301,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Fetch the type of service. </summary>
-        public int DifferentiatedServices
+        public Int32 DifferentiatedServices
         {
             get
             {
@@ -310,7 +310,7 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + IPv4Fields.DifferentiatedServicesPosition] = (byte)value;
+                header.Bytes[header.Offset + IPv4Fields.DifferentiatedServicesPosition] = (Byte)value;
             }
         }
 
@@ -318,7 +318,7 @@ namespace PacketDotNet
         /// Renamed to DifferentiatedServices in IPv6 but present here
         /// for backwards compatibility
         /// </value>
-        public int TypeOfService
+        public Int32 TypeOfService
         {
             get { return DifferentiatedServices; }
             set { DifferentiatedServices = value; }
@@ -327,7 +327,7 @@ namespace PacketDotNet
         /// <value>
         /// The entire datagram size including header and data
         /// </value>
-        public override int TotalLength
+        public override Int32 TotalLength
         {
             get
             {
@@ -346,7 +346,7 @@ namespace PacketDotNet
 
         /// <summary> Fetch fragment flags.</summary>
         /// <param name="flags">A 3-bit unsigned integer.</param>
-        public virtual int FragmentFlags
+        public virtual Int32 FragmentFlags
         {
             get
             {
@@ -364,7 +364,7 @@ namespace PacketDotNet
                                                                            header.Offset + IPv4Fields.FragmentOffsetAndFlagsPosition);
 
                 // mask the flags in
-                fragmentOffsetAndFlags = (short)((fragmentOffsetAndFlags & 0x1FFF) | ((value & 0x07) << (16 - 3)));
+                fragmentOffsetAndFlags = (Int16)((fragmentOffsetAndFlags & 0x1FFF) | ((value & 0x07) << (16 - 3)));
 
                 EndianBitConverter.Big.CopyBytes(fragmentOffsetAndFlags,
                                                  header.Bytes,
@@ -379,7 +379,7 @@ namespace PacketDotNet
         ///
         /// 8-bit value
         /// </summary>
-        public override int TimeToLive
+        public override Int32 TimeToLive
         {
             get
             {
@@ -388,7 +388,7 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + IPv4Fields.TtlPosition] = (byte)value;
+                header.Bytes[header.Offset + IPv4Fields.TtlPosition] = (Byte)value;
             }
         }
 
@@ -404,7 +404,7 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + IPv4Fields.ProtocolPosition] = (byte)value;
+                header.Bytes[header.Offset + IPv4Fields.ProtocolPosition] = (Byte)value;
             }
         }
 
@@ -413,11 +413,11 @@ namespace PacketDotNet
         /// </summary>
         /// <returns> The calculated IP checksum.
         /// </returns>
-        public ushort CalculateIPChecksum()
+        public UInt16 CalculateIPChecksum()
         {
             //copy the ip header
             var theHeader = Header;
-            byte[] ip = new byte[theHeader.Length];
+            Byte[] ip = new Byte[theHeader.Length];
             Array.Copy(theHeader, ip, theHeader.Length);
 
             //reset the checksum field (checksum is calculated when this field is zeroed)
@@ -425,9 +425,9 @@ namespace PacketDotNet
             EndianBitConverter.Big.CopyBytes(theValue, ip, IPv4Fields.ChecksumPosition);
 
             //calculate the one's complement sum of the ip header
-            int cs = ChecksumUtils.OnesComplementSum(ip, 0, ip.Length);
+            Int32 cs = ChecksumUtils.OnesComplementSum(ip, 0, ip.Length);
 
-            return (ushort)cs;
+            return (UInt16)cs;
         }
 
         /// <summary>
@@ -451,18 +451,18 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.Byte"/>
         /// </returns>
-        internal override byte[] AttachPseudoIPHeader(byte[] origHeader)
+        internal override Byte[] AttachPseudoIPHeader(Byte[] origHeader)
         {
             log.DebugFormat("origHeader.Length {0}",
                             origHeader.Length);
 
-            bool odd = origHeader.Length % 2 != 0;
-            int numberOfBytesFromIPHeaderUsedToGenerateChecksum = 12;
-            int headerSize = numberOfBytesFromIPHeaderUsedToGenerateChecksum + origHeader.Length;
+            Boolean odd = origHeader.Length % 2 != 0;
+            Int32 numberOfBytesFromIPHeaderUsedToGenerateChecksum = 12;
+            Int32 headerSize = numberOfBytesFromIPHeaderUsedToGenerateChecksum + origHeader.Length;
             if (odd)
                 headerSize++;
 
-            byte[] headerForChecksum = new byte[headerSize];
+            Byte[] headerForChecksum = new Byte[headerSize];
             // 0-7: ip src+dest addr
             Array.Copy(header.Bytes,
                        header.Offset + IPv4Fields.SourcePosition,
@@ -472,7 +472,7 @@ namespace PacketDotNet
             // 8: always zero
             headerForChecksum[8] = 0;
             // 9: ip protocol
-            headerForChecksum[9] = (byte)Protocol;
+            headerForChecksum[9] = (Byte)Protocol;
             // 10-11: header+data length
             var length = (Int16)origHeader.Length;
             EndianBitConverter.Big.CopyBytes(length, headerForChecksum,
@@ -497,9 +497,9 @@ namespace PacketDotNet
                           System.Net.IPAddress DestinationAddress)
         {
             // allocate memory for this packet
-            int offset = 0;
-            int length = IPv4Fields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = IPv4Fields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             // set some default values to make this packet valid
@@ -572,11 +572,11 @@ namespace PacketDotNet
 
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -600,18 +600,18 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("version", Version.ToString());
                 // FIXME: Header length output is incorrect
                 properties.Add("header length", HeaderLength + " bytes");
-                string diffServices =  Convert.ToString(DifferentiatedServices, 2).PadLeft(8, '0').Insert(4, " ");
+                String diffServices =  Convert.ToString(DifferentiatedServices, 2).PadLeft(8, '0').Insert(4, " ");
                 properties.Add("differentiated services", "0x" + DifferentiatedServices.ToString("x").PadLeft(2, '0'));
                 properties.Add("", diffServices.Substring(0, 7) + ".. = [" + (DifferentiatedServices >> 2) + "] code point");
                 properties.Add(" ",".... .." + diffServices[6] + ". = [" + diffServices[6] + "] ECN");
                 properties.Add("  ",".... ..." + diffServices[7] + " = [" + diffServices[7] + "] ECE");
                 properties.Add("total length", TotalLength.ToString());
                 properties.Add("identification", "0x" + Id.ToString("x") + " (" + Id + ")");
-                string flags = Convert.ToString(FragmentFlags, 2).PadLeft(8, '0').Substring(5, 3);
+                String flags = Convert.ToString(FragmentFlags, 2).PadLeft(8, '0').Substring(5, 3);
                 properties.Add("flags", "0x" + FragmentFlags.ToString("x").PadLeft(2, '0'));
                 properties.Add("   ", flags[0] + ".. = [" +  flags[0] + "] reserved");
                 properties.Add("    ", "." + flags[1] + ". = [" + flags[1] + "] don't fragment");
@@ -624,7 +624,7 @@ namespace PacketDotNet
                 properties.Add("destination", DestinationAddress.ToString());
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("IP:  ******* IPv4 - \"Internet Protocol (Version 4)\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/IPv6Fields.cs
+++ b/PacketDotNet/IPv6Fields.cs
@@ -17,6 +17,9 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  * Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary>
@@ -28,63 +31,63 @@ namespace PacketDotNet
         /// The IP Version, Traffic Class, and Flow Label field length. These must be in one
         /// field due to boundary crossings.
         /// </summary>
-        public readonly static int VersionTrafficClassFlowLabelLength = 4;
+        public readonly static Int32 VersionTrafficClassFlowLabelLength = 4;
 
         /// <summary>
         /// The payload length field length.
         /// </summary>
-        public readonly static int PayloadLengthLength = 2;
+        public readonly static Int32 PayloadLengthLength = 2;
 
         /// <summary>
         /// The next header field length, identifies protocol encapsulated by the packet
         /// </summary>
-        public readonly static int NextHeaderLength = 1;
+        public readonly static Int32 NextHeaderLength = 1;
 
         /// <summary>
         /// The hop limit field length.
         /// </summary>
-        public readonly static int HopLimitLength = 1;
+        public readonly static Int32 HopLimitLength = 1;
 
         /// <summary>
         /// Address field length
         /// </summary>
-        public readonly static int AddressLength = 16;
+        public readonly static Int32 AddressLength = 16;
 
         /// <summary>
         /// The byte position of the field line in the IPv6 header.
         /// This is where the IP version, Traffic Class, and Flow Label fields are.
         /// </summary>
-        public readonly static int VersionTrafficClassFlowLabelPosition = 0;
+        public readonly static Int32 VersionTrafficClassFlowLabelPosition = 0;
 
         /// <summary>
         /// The byte position of the payload length field.
         /// </summary>
-        public readonly static int PayloadLengthPosition;
+        public readonly static Int32 PayloadLengthPosition;
 
         /// <summary>
         /// The byte position of the next header field. (Replaces the ipv4 protocol field)
         /// </summary>
-        public readonly static int NextHeaderPosition;
+        public readonly static Int32 NextHeaderPosition;
 
         /// <summary>
         /// The byte position of the hop limit field.
         /// </summary>
-        public readonly static int HopLimitPosition;
+        public readonly static Int32 HopLimitPosition;
 
         /// <summary>
         /// The byte position of the source address field.
         /// </summary>
-        public readonly static int SourceAddressPosition;
+        public readonly static Int32 SourceAddressPosition;
 
         /// <summary>
         /// The byte position of the destination address field.
         /// </summary>
-        public readonly static int DestinationAddressPosition;
+        public readonly static Int32 DestinationAddressPosition;
 
         /// <summary>
         /// The byte length of the IPv6 Header
         /// </summary>
-        public readonly static int HeaderLength; // == 40
+        public readonly static Int32 HeaderLength; // == 40
 
         /// <summary>
         /// Commutes the field positions.

--- a/PacketDotNet/IPv6Packet.cs
+++ b/PacketDotNet/IPv6Packet.cs
@@ -52,7 +52,7 @@ namespace PacketDotNet
         /// <value>
         /// Minimum number of bytes in an IPv6 header
         /// </value>
-        public const int HeaderMinimumLength = 40;
+        public const Int32 HeaderMinimumLength = 40;
 
         /// <value>
         /// The version of the IP protocol. The '6' in IPv6 indicates the version of the protocol
@@ -94,14 +94,14 @@ namespace PacketDotNet
                 field = (UInt32)((field & 0x0FFFFFFF) | ((theValue << 28) & 0xF0000000));
 
                 // write the updated value back
-                VersionTrafficClassFlowLabel = (int)field;
+                VersionTrafficClassFlowLabel = (Int32)field;
             }
         }
 
         /// <summary>
         /// The traffic class field of the IPv6 Packet.
         /// </summary>
-        public virtual int TrafficClass
+        public virtual Int32 TrafficClass
         {
             get
             {
@@ -117,14 +117,14 @@ namespace PacketDotNet
                 field = (UInt32)(((field & 0xF00FFFFF) | (((UInt32)value) << 20 ) & 0x0FF00000));
 
                 // write the updated value back
-                VersionTrafficClassFlowLabel = (int)field;
+                VersionTrafficClassFlowLabel = (Int32)field;
             }
         }
 
         /// <summary>
         /// The flow label field of the IPv6 Packet.
         /// </summary>
-        public virtual int FlowLabel
+        public virtual Int32 FlowLabel
         {
             get
             {
@@ -140,7 +140,7 @@ namespace PacketDotNet
                 field = (UInt32)((field & 0xFFF00000) | ((UInt32)(value) & 0x000FFFFF));
 
                 // write the updated value back
-                VersionTrafficClassFlowLabel = (int)field;
+                VersionTrafficClassFlowLabel = (Int32)field;
             }
         }
 
@@ -149,7 +149,7 @@ namespace PacketDotNet
         /// NOTE: Differs from the IPv4 'Total length' field that includes the length of the header as
         ///       payload length is ONLY the size of the payload.
         /// </summary>
-        public override ushort PayloadLength
+        public override UInt16 PayloadLength
         {
             get
             {
@@ -169,7 +169,7 @@ namespace PacketDotNet
         /// Backwards compatibility property for IPv4.HeaderLength
         /// NOTE: This field is the number of 32bit words
         /// </value>
-        public override int HeaderLength
+        public override Int32 HeaderLength
         {
             get
             {
@@ -185,7 +185,7 @@ namespace PacketDotNet
         /// <value>
         /// Backwards compatibility property for IPv4.TotalLength
         /// </value>
-        public override int TotalLength
+        public override Int32 TotalLength
         {
             get
             {
@@ -194,7 +194,7 @@ namespace PacketDotNet
 
             set
             {
-                PayloadLength = (ushort)(value - (HeaderLength * 4));
+                PayloadLength = (UInt16)(value - (HeaderLength * 4));
             }
         }
 
@@ -212,7 +212,7 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + IPv6Fields.NextHeaderPosition] = (byte)value;
+                header.Bytes[header.Offset + IPv6Fields.NextHeaderPosition] = (Byte)value;
             }
         }
 
@@ -231,7 +231,7 @@ namespace PacketDotNet
         ///
         /// 8-bit value
         /// </summary>
-        public override int HopLimit
+        public override Int32 HopLimit
         {
             get
             {
@@ -240,14 +240,14 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + IPv6Fields.HopLimitPosition] = (byte)value;
+                header.Bytes[header.Offset + IPv6Fields.HopLimitPosition] = (Byte)value;
             }
         }
 
         /// <value>
         /// Helper alias for 'HopLimit'
         /// </value>
-        public override int TimeToLive
+        public override Int32 TimeToLive
         {
             get { return HopLimit; }
             set { HopLimit = value; }
@@ -267,7 +267,7 @@ namespace PacketDotNet
 
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 System.Array.Copy(address, 0,
                                   header.Bytes, header.Offset + IPv6Fields.SourceAddressPosition,
                                   address.Length);
@@ -288,7 +288,7 @@ namespace PacketDotNet
 
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 System.Array.Copy(address, 0,
                                   header.Bytes, header.Offset + IPv6Fields.DestinationAddressPosition,
                                   address.Length);
@@ -310,9 +310,9 @@ namespace PacketDotNet
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int length = IPv6Fields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = IPv6Fields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             // set some default values to make this packet valid
@@ -380,7 +380,7 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.Byte"/>
         /// </returns>
-        internal override byte[] AttachPseudoIPHeader(byte[] origHeader)
+        internal override Byte[] AttachPseudoIPHeader(Byte[] origHeader)
         {
             MemoryStream ms = new MemoryStream();
             BinaryWriter bw = new BinaryWriter(ms);
@@ -397,21 +397,21 @@ namespace PacketDotNet
             bw.Write((UInt32)System.Net.IPAddress.HostToNetworkOrder((Int32)origHeader.Length));
 
             // 37-39: 3 bytes of zeros
-            bw.Write((byte)0);
-            bw.Write((byte)0);
-            bw.Write((byte)0);
+            bw.Write((Byte)0);
+            bw.Write((Byte)0);
+            bw.Write((Byte)0);
 
             // 40: Next header
-            bw.Write((byte)NextHeader);
+            bw.Write((Byte)NextHeader);
 
             // prefix the pseudoHeader to the header+data
-            byte[] pseudoHeader = ms.ToArray();
-            int headerSize = pseudoHeader.Length + origHeader.Length;
-            bool odd = origHeader.Length % 2 != 0;
+            Byte[] pseudoHeader = ms.ToArray();
+            Int32 headerSize = pseudoHeader.Length + origHeader.Length;
+            Boolean odd = origHeader.Length % 2 != 0;
             if (odd)
                 headerSize++;
 
-            byte[] finalData = new byte[headerSize];
+            Byte[] finalData = new Byte[headerSize];
 
             // copy the pseudo header in
             Array.Copy(pseudoHeader, 0, finalData, 0, pseudoHeader.Length);
@@ -427,11 +427,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -453,12 +453,12 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
-                string ipVersion = Convert.ToString((int)Version, 2).PadLeft(4, '0');
-                properties.Add("version", ipVersion + " .... .... .... .... .... .... .... = " + (int)Version);
-                string trafficClass = Convert.ToString(TrafficClass, 2).PadLeft(8, '0').Insert(4, " ");
+                Dictionary<String,String> properties = new Dictionary<String,String>();
+                String ipVersion = Convert.ToString((Int32)Version, 2).PadLeft(4, '0');
+                properties.Add("version", ipVersion + " .... .... .... .... .... .... .... = " + (Int32)Version);
+                String trafficClass = Convert.ToString(TrafficClass, 2).PadLeft(8, '0').Insert(4, " ");
                 properties.Add("traffic class", ".... " + trafficClass + " .... .... .... .... .... = 0x" + TrafficClass.ToString("x").PadLeft(8, '0'));
-                string flowLabel = Convert.ToString(FlowLabel, 2).PadLeft(20, '0').Insert(16, " ").Insert(12, " ").Insert(8, " ").Insert(4, " ");
+                String flowLabel = Convert.ToString(FlowLabel, 2).PadLeft(20, '0').Insert(16, " ").Insert(12, " ").Insert(8, " ").Insert(4, " ");
                 properties.Add("flow label", ".... .... .... " + flowLabel + " = 0x" + FlowLabel.ToString("x").PadLeft(8, '0'));
                 properties.Add("payload length", PayloadLength.ToString());
                 properties.Add("next header", NextHeader.ToString() + " (0x" + NextHeader.ToString("x") + ")");
@@ -467,7 +467,7 @@ namespace PacketDotNet
                 properties.Add("destination", DestinationAddress.ToString());
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("IP:  ******* IP - \"Internet Protocol (Version 6)\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/Ieee80211/AckFrame.cs
+++ b/PacketDotNet/Ieee80211/AckFrame.cs
@@ -41,7 +41,7 @@ namespace PacketDotNet
             /// <summary>
             /// Length of the frame
             /// </summary>
-            override public int FrameSize
+            override public Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/ActionFrame.cs
+++ b/PacketDotNet/Ieee80211/ActionFrame.cs
@@ -89,7 +89,7 @@ namespace PacketDotNet
             /// <value>
             /// The size of the frame.
             /// </value>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/AssociationRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/AssociationRequestFrame.cs
@@ -37,12 +37,12 @@ namespace PacketDotNet
         {
             private class AssociationRequestFields
             {
-                public readonly static int CapabilityInformationLength = 2;
-                public readonly static int ListenIntervalLength = 2;
+                public readonly static Int32 CapabilityInformationLength = 2;
+                public readonly static Int32 ListenIntervalLength = 2;
 
-                public readonly static int CapabilityInformationPosition;
-                public readonly static int ListenIntervalPosition;
-                public readonly static int InformationElement1Position;
+                public readonly static Int32 CapabilityInformationPosition;
+                public readonly static Int32 ListenIntervalPosition;
+                public readonly static Int32 InformationElement1Position;
 
                 static AssociationRequestFields()
                 {
@@ -136,7 +136,7 @@ namespace PacketDotNet
             /// <value>
             /// The size of the frame.
             /// </value>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/AssociationResponseFrame.cs
+++ b/PacketDotNet/Ieee80211/AssociationResponseFrame.cs
@@ -37,14 +37,14 @@ namespace PacketDotNet
         {
             private class AssociationResponseFields
             {
-                public readonly static int CapabilityInformationLength = 2;
-                public readonly static int StatusCodeLength = 2;
-                public readonly static int AssociationIdLength = 2;
+                public readonly static Int32 CapabilityInformationLength = 2;
+                public readonly static Int32 StatusCodeLength = 2;
+                public readonly static Int32 AssociationIdLength = 2;
 
-                public readonly static int CapabilityInformationPosition;
-                public readonly static int StatusCodePosition;
-                public readonly static int AssociationIdPosition;
-                public readonly static int InformationElement1Position;
+                public readonly static Int32 CapabilityInformationPosition;
+                public readonly static Int32 StatusCodePosition;
+                public readonly static Int32 AssociationIdPosition;
+                public readonly static Int32 InformationElement1Position;
 
                 static AssociationResponseFields()
                 {
@@ -164,7 +164,7 @@ namespace PacketDotNet
             /// <value>
             /// The size of the frame.
             /// </value>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/AuthenticationFrame.cs
+++ b/PacketDotNet/Ieee80211/AuthenticationFrame.cs
@@ -37,13 +37,13 @@ namespace PacketDotNet
         {
             private class AuthenticationFields
             {
-                public readonly static int AuthAlgorithmNumLength = 2;
-                public readonly static int AuthAlgorithmTransactionSequenceNumLength = 2;
-                public readonly static int StatusCodeLength = 2;
-                public readonly static int AuthAlgorithmNumPosition;
-                public readonly static int AuthAlgorithmTransactionSequenceNumPosition;
-                public readonly static int StatusCodePosition;
-                public readonly static int InformationElement1Position;
+                public readonly static Int32 AuthAlgorithmNumLength = 2;
+                public readonly static Int32 AuthAlgorithmTransactionSequenceNumLength = 2;
+                public readonly static Int32 StatusCodeLength = 2;
+                public readonly static Int32 AuthAlgorithmNumPosition;
+                public readonly static Int32 AuthAlgorithmTransactionSequenceNumPosition;
+                public readonly static Int32 StatusCodePosition;
+                public readonly static Int32 InformationElement1Position;
 
                 static AuthenticationFields ()
                 {
@@ -153,7 +153,7 @@ namespace PacketDotNet
             /// <value>
             /// The size of the frame.
             /// </value>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/BeaconFrame.cs
+++ b/PacketDotNet/Ieee80211/BeaconFrame.cs
@@ -42,14 +42,14 @@ namespace PacketDotNet
 
             private class BeaconFields
             {
-                public readonly static int TimestampLength = 8;
-                public readonly static int BeaconIntervalLength = 2;
-                public readonly static int CapabilityInformationLength = 2;
+                public readonly static Int32 TimestampLength = 8;
+                public readonly static Int32 BeaconIntervalLength = 2;
+                public readonly static Int32 CapabilityInformationLength = 2;
 
-                public readonly static int TimestampPosition;
-                public readonly static int BeaconIntervalPosition;
-                public readonly static int CapabilityInformationPosition;
-                public readonly static int InformationElement1Position;
+                public readonly static Int32 TimestampPosition;
+                public readonly static Int32 BeaconIntervalPosition;
+                public readonly static Int32 CapabilityInformationPosition;
+                public readonly static Int32 InformationElement1Position;
 
                 static BeaconFields ()
                 {
@@ -160,7 +160,7 @@ namespace PacketDotNet
             /// <value>
             /// The size of the frame.
             /// </value>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/BlockAcknowledgmentControlField.cs
+++ b/PacketDotNet/Ieee80211/BlockAcknowledgmentControlField.cs
@@ -73,7 +73,7 @@ namespace PacketDotNet
             /// <summary>
             /// True if the acknowledgement can ack multi traffic ids
             /// </summary>
-            public bool MultiTid
+            public Boolean MultiTid
             {
                 get
                 {
@@ -98,7 +98,7 @@ namespace PacketDotNet
             /// 
             /// Newer standards used a compressed bitmap reducing its size
             /// </summary>
-            public bool CompressedBitmap
+            public Boolean CompressedBitmap
             {
                 get
                 {
@@ -121,11 +121,11 @@ namespace PacketDotNet
             /// <summary>
             /// The traffic id being ack'd
             /// </summary>
-            public byte Tid
+            public Byte Tid
             {
                 get
                 {
-                    return (byte)(Field >> 12);
+                    return (Byte)(Field >> 12);
                 }
                 
                 set

--- a/PacketDotNet/Ieee80211/BlockAcknowledgmentFrame.cs
+++ b/PacketDotNet/Ieee80211/BlockAcknowledgmentFrame.cs
@@ -38,12 +38,12 @@ namespace PacketDotNet
         {
             private class BlockAcknowledgmentField
             {
-                public readonly static int BlockAckRequestControlLength = 2;
-                public readonly static int BlockAckStartingSequenceControlLength = 2;
+                public readonly static Int32 BlockAckRequestControlLength = 2;
+                public readonly static Int32 BlockAckStartingSequenceControlLength = 2;
 
-                public readonly static int BlockAckRequestControlPosition;
-                public readonly static int BlockAckStartingSequenceControlPosition;
-                public readonly static int BlockAckBitmapPosition;
+                public readonly static Int32 BlockAckRequestControlPosition;
+                public readonly static Int32 BlockAckStartingSequenceControlPosition;
+                public readonly static Int32 BlockAckBitmapPosition;
 
                 static BlockAcknowledgmentField()
                 {
@@ -134,7 +134,7 @@ namespace PacketDotNet
                 }
             }
    
-            private byte[] blockAckBitmap;
+            private Byte[] blockAckBitmap;
             /// <summary>
             /// Gets or sets the block ack bitmap used to indicate the receive status of the MPDUs.
             /// </summary>
@@ -201,7 +201,7 @@ namespace PacketDotNet
             /// <summary>
             /// Length of the frame
             /// </summary>
-            override public int FrameSize
+            override public Int32 FrameSize
             {
                 get
                 {
@@ -215,7 +215,7 @@ namespace PacketDotNet
             }
 
 
-            private int GetBitmapLength()
+            private Int32 GetBitmapLength()
             {
                 return BlockAcknowledgmentControl.CompressedBitmap ? 8 : 64;
             }

--- a/PacketDotNet/Ieee80211/BlockAcknowledgmentRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/BlockAcknowledgmentRequestFrame.cs
@@ -37,11 +37,11 @@ namespace PacketDotNet
         {
             private class BlockAckRequestField
             {
-                public readonly static int BlockAckRequestControlLength = 2;
-                public readonly static int BlockAckStartingSequenceControlLength = 2;
+                public readonly static Int32 BlockAckRequestControlLength = 2;
+                public readonly static Int32 BlockAckStartingSequenceControlLength = 2;
 
-                public readonly static int BlockAckRequestControlPosition;
-                public readonly static int BlockAckStartingSequenceControlPosition;
+                public readonly static Int32 BlockAckRequestControlPosition;
+                public readonly static Int32 BlockAckStartingSequenceControlPosition;
 
                 static BlockAckRequestField()
                 {
@@ -141,7 +141,7 @@ namespace PacketDotNet
             /// <summary>
             /// Length of the frame
             /// </summary>
-            override public int FrameSize
+            override public Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/CapabilityInformationField.cs
+++ b/PacketDotNet/Ieee80211/CapabilityInformationField.cs
@@ -38,7 +38,7 @@ namespace PacketDotNet
             /// 
             /// This field and IsIbss should be mutually exclusive
             /// </summary>
-            public bool IsEss
+            public Boolean IsEss
             {
                 get
                 {
@@ -56,7 +56,7 @@ namespace PacketDotNet
             /// 
             /// This field and IsEss should be mutually exclusive
             /// </summary>
-            public bool IsIbss
+            public Boolean IsIbss
             {
                 get
                 {
@@ -76,7 +76,7 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if cf pollable; otherwise, <c>false</c>.
             /// </value>
-            public bool CfPollable
+            public Boolean CfPollable
             {
                 get
                 {
@@ -96,7 +96,7 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if cf poll request; otherwise, <c>false</c>.
             /// </value>
-            public bool CfPollRequest
+            public Boolean CfPollRequest
             {
                 get
                 {
@@ -116,7 +116,7 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if privacy; otherwise, <c>false</c>.
             /// </value>
-            public bool Privacy
+            public Boolean Privacy
             {
                 get
                 {
@@ -136,7 +136,7 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if short preamble; otherwise, <c>false</c>.
             /// </value>
-            public bool ShortPreamble
+            public Boolean ShortPreamble
             {
                 get
                 {
@@ -156,7 +156,7 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if pbcc; otherwise, <c>false</c>.
             /// </value>
-            public bool Pbcc
+            public Boolean Pbcc
             {
                 get
                 {
@@ -176,7 +176,7 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if channel agility; otherwise, <c>false</c>.
             /// </value>
-            public bool ChannelAgility
+            public Boolean ChannelAgility
             {
                 get
                 {
@@ -196,7 +196,7 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if short time slot; otherwise, <c>false</c>.
             /// </value>
-            public bool ShortTimeSlot
+            public Boolean ShortTimeSlot
             {
                 get
                 {
@@ -216,7 +216,7 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if dss ofdm; otherwise, <c>false</c>.
             /// </value>
-            public bool DssOfdm
+            public Boolean DssOfdm
             {
                 get
                 {
@@ -233,12 +233,12 @@ namespace PacketDotNet
             /// Returns true if the bit is set false if not.
             /// </summary>
             /// <param name="index">0 indexed position of the bit</param>
-            private bool GetBitFieldValue(ushort index)
+            private Boolean GetBitFieldValue(UInt16 index)
             {
                 return (((Field >> index) & 0x1) == 1) ? true : false;
             }
 
-            private void SetBitFieldValue(ushort index, bool value)
+            private void SetBitFieldValue(UInt16 index, Boolean value)
             {
                 if (value)
                 {

--- a/PacketDotNet/Ieee80211/ContentionFreeEndFrame.cs
+++ b/PacketDotNet/Ieee80211/ContentionFreeEndFrame.cs
@@ -47,7 +47,7 @@ namespace PacketDotNet
             /// <summary>
             /// Length of the frame
             /// </summary>
-            override public int FrameSize
+            override public Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/CtsFrame.cs
+++ b/PacketDotNet/Ieee80211/CtsFrame.cs
@@ -42,7 +42,7 @@ namespace PacketDotNet
             /// <summary>
             /// Length of the frame
             /// </summary>
-            override public int FrameSize
+            override public Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/DataDataFrame.cs
+++ b/PacketDotNet/Ieee80211/DataDataFrame.cs
@@ -39,12 +39,12 @@ namespace PacketDotNet
             /// <value>
             /// The size of the frame.
             /// </value>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {
                     //if we are in WDS mode then there are 4 addresses (normally it is just 3)
-                    int numOfAddressFields = (FrameControl.ToDS && FrameControl.FromDS) ? 4 : 3;
+                    Int32 numOfAddressFields = (FrameControl.ToDS && FrameControl.FromDS) ? 4 : 3;
 
                     return (MacFields.FrameControlLength +
                         MacFields.DurationIDLength +

--- a/PacketDotNet/Ieee80211/DeauthenticationFrame.cs
+++ b/PacketDotNet/Ieee80211/DeauthenticationFrame.cs
@@ -37,9 +37,9 @@ namespace PacketDotNet
         {
             private class DeauthenticationFields
             {
-                public readonly static int ReasonCodeLength = 2;
+                public readonly static Int32 ReasonCodeLength = 2;
 
-                public readonly static int ReasonCodePosition;
+                public readonly static Int32 ReasonCodePosition;
 
                 static DeauthenticationFields()
                 {
@@ -84,7 +84,7 @@ namespace PacketDotNet
             /// <value>
             /// The size of the frame.
             /// </value>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/DisassociationFrame.cs
+++ b/PacketDotNet/Ieee80211/DisassociationFrame.cs
@@ -37,9 +37,9 @@ namespace PacketDotNet
         {
             private class DisassociationFields
             {
-                public readonly static int ReasonCodeLength = 2;
+                public readonly static Int32 ReasonCodeLength = 2;
 
-                public readonly static int ReasonCodePosition;
+                public readonly static Int32 ReasonCodePosition;
 
                 static DisassociationFields()
                 {
@@ -84,7 +84,7 @@ namespace PacketDotNet
             /// <value>
             /// The size of the frame.
             /// </value>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/FrameControlField.cs
+++ b/PacketDotNet/Ieee80211/FrameControlField.cs
@@ -36,11 +36,11 @@ namespace PacketDotNet
             /// <summary>
             /// Protocol version
             /// </summary>
-            public byte ProtocolVersion
+            public Byte ProtocolVersion
             {
                 get
                 {
-                    return (byte)((Field >> 0x8) & 0x3);
+                    return (Byte)((Field >> 0x8) & 0x3);
                 }
 
                 set
@@ -285,8 +285,8 @@ namespace PacketDotNet
             {
                 get
                 {
-                    int typeAndSubtype = (Field >> 8); //get rid of the flags
-                    int type = ((typeAndSubtype & 0xC) >> 2);
+                    Int32 typeAndSubtype = (Field >> 8); //get rid of the flags
+                    Int32 type = ((typeAndSubtype & 0xC) >> 2);
                     return (FrameTypes)type;
                 }
             }
@@ -299,15 +299,15 @@ namespace PacketDotNet
             {
                 get
                 {
-                    int typeAndSubtype = (Field >> 8); //get rid of the flags
-                    int type = (((typeAndSubtype & 0x0C) << 2) | (typeAndSubtype >> 4));
+                    Int32 typeAndSubtype = (Field >> 8); //get rid of the flags
+                    Int32 type = (((typeAndSubtype & 0x0C) << 2) | (typeAndSubtype >> 4));
                     return (FrameSubTypes)type;
                 }
 
                 set
                 {
-                    uint val = (uint)value;
-                    uint typeAndSubtype = ((val & 0x0F) << 4) | ((val >> 4) << 2);
+                    UInt32 val = (UInt32)value;
+                    UInt32 typeAndSubtype = ((val & 0x0F) << 4) | ((val >> 4) << 2);
                     //shift it into the right position in the field
                     typeAndSubtype = typeAndSubtype << 0x8;
                     //Unset all the bits related to the type and subtype
@@ -320,7 +320,7 @@ namespace PacketDotNet
             /// <summary>
             /// Is set to 1 when the frame is sent to Distribution System (DS)
             /// </summary>
-            public bool ToDS
+            public Boolean ToDS
             {
                 get
                 {
@@ -343,7 +343,7 @@ namespace PacketDotNet
             /// <summary>
             /// Is set to 1 when the frame is received from the Distribution System (DS)
             /// </summary>
-            public bool FromDS
+            public Boolean FromDS
             {
                 get
                 {
@@ -367,7 +367,7 @@ namespace PacketDotNet
             /// More Fragment is set to 1 when there are more fragments belonging to the same
             /// frame following the current fragment
             /// </summary>
-            public bool MoreFragments
+            public Boolean MoreFragments
             {
                 get
                 {
@@ -391,7 +391,7 @@ namespace PacketDotNet
             /// Indicates that this fragment is a retransmission of a previously transmitted fragment.
             /// (For receiver to recognize duplicate transmissions of frames)
             /// </summary>
-            public bool Retry
+            public Boolean Retry
             {
                 get
                 {
@@ -414,7 +414,7 @@ namespace PacketDotNet
             /// <summary>
             ///  Indicates the power management mode that the station will be in after the transmission of the frame
             /// </summary>
-            public bool PowerManagement
+            public Boolean PowerManagement
             {
                 get
                 {
@@ -437,7 +437,7 @@ namespace PacketDotNet
             /// <summary>
             /// Indicates that there are more frames buffered for this station
             /// </summary>
-            public bool MoreData
+            public Boolean MoreData
             {
                 get
                 {
@@ -461,7 +461,7 @@ namespace PacketDotNet
             /// Indicates that the frame body is encrypted according to the WEP (wired equivalent privacy) algorithm
             /// </summary>
             [ObsoleteAttribute("This property is obsolete. Use Protected instead.", false)]
-            public bool Wep
+            public Boolean Wep
             {
                 get { return Protected; }
                 set { Protected = value; }
@@ -470,7 +470,7 @@ namespace PacketDotNet
             /// <summary>
             /// Indicates whether the frame body is encrypted with one of several encryption standards
             /// </summary>
-            public bool Protected
+            public Boolean Protected
             {
                 get
                 {
@@ -494,7 +494,7 @@ namespace PacketDotNet
             /// Bit is set when the "strict ordering" delivery method is employed. Frames and
             /// fragments are not always sent in order as it causes a transmission performance penalty.
             /// </summary>
-            public bool Order
+            public Boolean Order
             {
                 get
                 {
@@ -547,7 +547,7 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/> that represents the current <see cref="PacketDotNet.Ieee80211.FrameControlField"/>.
             /// </returns>
-            public override string ToString ()
+            public override String ToString ()
             {
                 var flags = new List<String>();
                 

--- a/PacketDotNet/Ieee80211/InformationElement.cs
+++ b/PacketDotNet/Ieee80211/InformationElement.cs
@@ -39,23 +39,23 @@ namespace PacketDotNet
             /// <summary>
             /// The length in bytes of the Information Element id field.
             /// </summary>
-            public readonly static int ElementIdLength = 1;
+            public readonly static Int32 ElementIdLength = 1;
             /// <summary>
             /// The length in bytes of the Information Element length field.
             /// </summary>
-            public readonly static int ElementLengthLength = 1;
+            public readonly static Int32 ElementLengthLength = 1;
             /// <summary>
             /// The index of the id field in an Information Element.
             /// </summary>
-            public readonly static int ElementIdPosition = 0;
+            public readonly static Int32 ElementIdPosition = 0;
             /// <summary>
             /// The index of the length field in an Information Element.
             /// </summary>
-            public readonly static int ElementLengthPosition;
+            public readonly static Int32 ElementLengthPosition;
             /// <summary>
             /// The index of the first byte of the value field in an Information Element.
             /// </summary>
-            public readonly static int ElementValuePosition;
+            public readonly static Int32 ElementValuePosition;
 
             static InformationElement ()
             {
@@ -243,7 +243,7 @@ namespace PacketDotNet
                 }
                 set
                 {
-                    bytes.Bytes [bytes.Offset + ElementIdPosition] = (byte)value;
+                    bytes.Bytes [bytes.Offset + ElementIdPosition] = (Byte)value;
                 }
             }
 
@@ -253,7 +253,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public int ValueLength
+            public Int32 ValueLength
             {
                 get
                 {
@@ -270,11 +270,11 @@ namespace PacketDotNet
             /// <value>
             /// The length of the element.
             /// </value>
-            public byte ElementLength
+            public Byte ElementLength
             {
                 get
                 {
-                    return (byte)(ElementIdLength + ElementLengthLength + ValueLength);
+                    return (Byte)(ElementIdLength + ElementLengthLength + ValueLength);
                 }
                 //no set Length method as we dont want to allow a mismatch between
                 //the length field and the actual length of the value
@@ -303,12 +303,12 @@ namespace PacketDotNet
                 
                 set
                 {
-                    if (value.Length > byte.MaxValue)
+                    if (value.Length > Byte.MaxValue)
                     {
                         throw new ArgumentException ("The provided value is too long. Maximum allowed length is 255 bytes.");
                     }
                     //Decide if the current ByteArraySegement is big enough to hold the new info element
-                    int newIeLength = ElementIdLength + ElementLengthLength + value.Length;
+                    Int32 newIeLength = ElementIdLength + ElementLengthLength + value.Length;
                     if (bytes.Length < newIeLength)
                     {
                         var newIe = new Byte[newIeLength];
@@ -318,7 +318,7 @@ namespace PacketDotNet
                     
                     Array.Copy (value, 0, bytes.Bytes, bytes.Offset + ElementValuePosition, value.Length);
                     bytes.Length = newIeLength;
-                    bytes.Bytes [bytes.Offset + ElementLengthPosition] = (byte)value.Length;
+                    bytes.Bytes [bytes.Offset + ElementLengthPosition] = (Byte)value.Length;
                     
                 }
             }
@@ -347,7 +347,7 @@ namespace PacketDotNet
             /// <c>true</c> if the specified <see cref="System.Object"/> is equal to the current
             /// <see cref="PacketDotNet.Ieee80211.InformationElement"/>; otherwise, <c>false</c>.
             /// </returns>
-            public override bool Equals(object obj)
+            public override Boolean Equals(Object obj)
             {
                 if (obj == null || GetType() != obj.GetType())
                 {
@@ -365,7 +365,7 @@ namespace PacketDotNet
             /// A hash code for this instance that is suitable for use in hashing algorithms and data structures such as
             /// a hash table.
             /// </returns>
-            public override int GetHashCode()
+            public override Int32 GetHashCode()
             {
                 return Id.GetHashCode() ^ Value.GetHashCode();
             }

--- a/PacketDotNet/Ieee80211/InformationElementList.cs
+++ b/PacketDotNet/Ieee80211/InformationElementList.cs
@@ -66,7 +66,7 @@ namespace PacketDotNet
             /// </param>
             public InformationElementList (ByteArraySegment bas)
             {
-                int index = 0;
+                Int32 index = 0;
                 while ((index + InformationElement.ElementLengthPosition) < bas.Length)
                 {
                     var ieStartPosition = bas.Offset + index;
@@ -85,11 +85,11 @@ namespace PacketDotNet
             /// <value>
             /// The length
             /// </value>
-            public int Length
+            public Int32 Length
             {
                 get
                 {
-                    int length = 0;
+                    Int32 length = 0;
                     foreach (InformationElement ie in this)
                     {
                         length += ie.ElementLength;
@@ -110,7 +110,7 @@ namespace PacketDotNet
                 get
                 {
                     var bytes = new Byte[Length];
-                    int index = 0;
+                    Int32 index = 0;
                     foreach (var ie in this)
                     {
                         var ieBytes = ie.Bytes;
@@ -165,9 +165,9 @@ namespace PacketDotNet
             /// </param>
             /// <remarks>Ensure that the destination is large enough to contain serialised elements
             /// before calling this method</remarks>
-            public void CopyTo (ByteArraySegment destination, int offset)
+            public void CopyTo (ByteArraySegment destination, Int32 offset)
             {
-                int index = 0;
+                Int32 index = 0;
                 foreach (var ie in this)
                 {
                     var ieBytes = ie.Bytes;

--- a/PacketDotNet/Ieee80211/LogicalLinkControl.cs
+++ b/PacketDotNet/Ieee80211/LogicalLinkControl.cs
@@ -48,7 +48,7 @@ namespace PacketDotNet
             /// Gets or sets the destination service access point.
             /// </summary>
             /// <value>The dsap.</value>
-            public byte DSAP
+            public Byte DSAP
             {
                 get
                 {
@@ -65,7 +65,7 @@ namespace PacketDotNet
             /// Gets or sets the source service access point.
             /// </summary>
             /// <value>The ssap.</value>
-            public byte SSAP
+            public Byte SSAP
             {
                 get
                 {
@@ -103,11 +103,11 @@ namespace PacketDotNet
             /// Gets or sets the control.
             /// </summary>
             /// <value>The control.</value>
-            public byte Control
+            public Byte Control
             {
                 get
                 {
-                    return (byte)((ControlOrganizationCode >> 24) & 0xFF);
+                    return (Byte)((ControlOrganizationCode >> 24) & 0xFF);
                 }
 
                 set
@@ -124,7 +124,7 @@ namespace PacketDotNet
             {
                 get
                 {
-                    return (byte)((ControlOrganizationCode & 0x00FFFFFF));
+                    return (Byte)((ControlOrganizationCode & 0x00FFFFFF));
                 }
 
                 set

--- a/PacketDotNet/Ieee80211/LogicalLinkControlFields.cs
+++ b/PacketDotNet/Ieee80211/LogicalLinkControlFields.cs
@@ -25,17 +25,17 @@ namespace PacketDotNet
     {
         class LogicalLinkControlFields
         {
-            public readonly static int DsapLength = 1;
-            public readonly static int SsapLength = 1;
-            public readonly static int ControlOrganizationLength = 4;
-            public readonly static int TypeLength = 2;
+            public readonly static Int32 DsapLength = 1;
+            public readonly static Int32 SsapLength = 1;
+            public readonly static Int32 ControlOrganizationLength = 4;
+            public readonly static Int32 TypeLength = 2;
 
-            public readonly static int DsapPosition = 0;
-            public readonly static int SsapPosition = DsapPosition + DsapLength;
-            public readonly static int ControlOrganizationPosition = SsapPosition + SsapLength;
-            public readonly static int TypePosition = ControlOrganizationPosition + ControlOrganizationLength;
+            public readonly static Int32 DsapPosition = 0;
+            public readonly static Int32 SsapPosition = DsapPosition + DsapLength;
+            public readonly static Int32 ControlOrganizationPosition = SsapPosition + SsapLength;
+            public readonly static Int32 TypePosition = ControlOrganizationPosition + ControlOrganizationLength;
 
-            public readonly static int HeaderLength = TypePosition + TypeLength;
+            public readonly static Int32 HeaderLength = TypePosition + TypeLength;
 
             static LogicalLinkControlFields()
             {

--- a/PacketDotNet/Ieee80211/MacFields.cs
+++ b/PacketDotNet/Ieee80211/MacFields.cs
@@ -32,19 +32,19 @@ namespace PacketDotNet
         /// </summary>
         class MacFields
         {
-            public readonly static int FrameControlLength = 2;
-            public readonly static int DurationIDLength = 2;
-            public readonly static int AddressLength = EthernetFields.MacAddressLength;
-            public readonly static int SequenceControlLength = 2;
-            public readonly static int FrameCheckSequenceLength = 4;
+            public readonly static Int32 FrameControlLength = 2;
+            public readonly static Int32 DurationIDLength = 2;
+            public readonly static Int32 AddressLength = EthernetFields.MacAddressLength;
+            public readonly static Int32 SequenceControlLength = 2;
+            public readonly static Int32 FrameCheckSequenceLength = 4;
 
-            public readonly static int FrameControlPosition = 0;
-            public readonly static int DurationIDPosition;
+            public readonly static Int32 FrameControlPosition = 0;
+            public readonly static Int32 DurationIDPosition;
             /// <summary>
             /// Not all MAC Frames contain a sequence control field. The value of this field is only meaningful when they do.
             /// </summary>
-            public readonly static int SequenceControlPosition;
-            public readonly static int Address1Position;
+            public readonly static Int32 SequenceControlPosition;
+            public readonly static Int32 Address1Position;
 
             static MacFields()
             {

--- a/PacketDotNet/Ieee80211/MacFrame.cs
+++ b/PacketDotNet/Ieee80211/MacFrame.cs
@@ -43,9 +43,9 @@ namespace PacketDotNet
 #endif
    
             
-            private int GetOffsetForAddress(int addressIndex)
+            private Int32 GetOffsetForAddress(Int32 addressIndex)
             {
-                int offset = header.Offset;
+                Int32 offset = header.Offset;
 
                 offset += MacFields.Address1Position + MacFields.AddressLength * addressIndex;
 
@@ -134,7 +134,7 @@ namespace PacketDotNet
             /// the type of frame. There are between 1 and 4 address fields in MAC frames</remarks>
             /// <param name="addressIndex">Zero based address to look up</param>
             /// <param name="address"></param>
-            protected void SetAddress(int addressIndex, PhysicalAddress address)
+            protected void SetAddress(Int32 addressIndex, PhysicalAddress address)
             {
                 var offset = GetOffsetForAddress(addressIndex);
                 SetAddressByOffset(offset, address);
@@ -151,13 +151,13 @@ namespace PacketDotNet
             /// <param name='address'>
             /// Address.
             /// </param>
-            protected void SetAddressByOffset(int offset, PhysicalAddress address)
+            protected void SetAddressByOffset(Int32 offset, PhysicalAddress address)
             {
-				byte[] hwAddress = null;
+				Byte[] hwAddress = null;
 				//We will replace no address with a MAC of all zer
 				if(address == PhysicalAddress.None)
 				{
-					hwAddress = new byte[]{0, 0, 0, 0, 0, 0};
+					hwAddress = new Byte[]{0, 0, 0, 0, 0, 0};
 				}
 				else
 				{
@@ -185,7 +185,7 @@ namespace PacketDotNet
             /// <param name='addressIndex'>
             /// Address index.
             /// </param>
-            protected PhysicalAddress GetAddress(int addressIndex)
+            protected PhysicalAddress GetAddress(Int32 addressIndex)
             {
                 var offset = GetOffsetForAddress(addressIndex);
                 return GetAddressByOffset(offset);
@@ -200,11 +200,11 @@ namespace PacketDotNet
             /// <param name='offset'>
             /// The offset into the packet buffer at which to start parsing the address.
             /// </param>
-            protected PhysicalAddress GetAddressByOffset(int offset)
+            protected PhysicalAddress GetAddressByOffset(Int32 offset)
             {
 				if((header.Offset + header.Length) >= (offset + MacFields.AddressLength))
 				{
-        	        byte[] hwAddress = new byte[MacFields.AddressLength];
+        	        Byte[] hwAddress = new Byte[MacFields.AddressLength];
             	    Array.Copy(header.Bytes, offset,
                 	           hwAddress, 0, hwAddress.Length);
                 	return new PhysicalAddress(hwAddress);
@@ -228,7 +228,7 @@ namespace PacketDotNet
             {
                 var bytes = Bytes;
                 var length = (AppendFcs) ? bytes.Length - 4 : bytes.Length;
-                FrameCheckSequence = (uint) Crc32.Compute(Bytes, 0, length);
+                FrameCheckSequence = (UInt32) Crc32.Compute(Bytes, 0, length);
             }
 
             /// <summary>
@@ -237,7 +237,7 @@ namespace PacketDotNet
             /// This does not include the FCS, it represents only the header bytes that would
             /// would preceed any payload.
             /// </summary>
-            public abstract int FrameSize { get; }
+            public abstract Int32 FrameSize { get; }
             
             /// <summary>
             /// Returns the number of bytes of payload data currently available in
@@ -249,9 +249,9 @@ namespace PacketDotNet
             /// <value>
             /// The number of bytes of space available after the header for payload data.
             /// </value>
-			protected int GetAvailablePayloadLength()
+			protected Int32 GetAvailablePayloadLength()
 			{
-				int payloadLength = header.BytesLength - (header.Offset + FrameSize);
+				Int32 payloadLength = header.BytesLength - (header.Offset + FrameSize);
 				return (payloadLength > 0) ? payloadLength : 0;
 			}
 			
@@ -480,10 +480,10 @@ namespace PacketDotNet
             /// <remarks>This method can be used to check the validity of a packet before attempting to parse it with either 
             /// <see cref="MacFrame.ParsePacket"/> or <see cref="MacFrame.ParsePacketWithFcs"/>. Attempting to parse a corrupted buffer
             /// using these methods could cause unexpected exceptions.</remarks>
-            public static bool PerformFcsCheck (Byte[] data, int offset, int length, UInt32 fcs)
+            public static Boolean PerformFcsCheck (Byte[] data, Int32 offset, Int32 length, UInt32 fcs)
             {
                 // Cast to uint for proper comparison to FrameCheckSequence
-                var check = (uint)Crc32.Compute(data, offset, length);
+                var check = (UInt32)Crc32.Compute(data, offset, length);
                 return check == fcs;
             }
 
@@ -493,7 +493,7 @@ namespace PacketDotNet
             /// <returns>
             /// The valid.
             /// </returns>
-            public bool FCSValid
+            public Boolean FCSValid
             {
                 get
                 {
@@ -510,7 +510,7 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if append FCS should be appended; otherwise, <c>false</c>.
             /// </value>
-            public bool AppendFcs { get; set; }
+            public Boolean AppendFcs { get; set; }
             
             
             /// <value>
@@ -588,7 +588,7 @@ namespace PacketDotNet
             /// </returns>
             public override String ToString()
             {
-                return string.Format ("802.11 MacFrame: [{0}], {1} FCS {2}",
+                return String.Format ("802.11 MacFrame: [{0}], {1} FCS {2}",
                                       FrameControl.ToString(),
                                       GetAddressString(),
                                       FrameCheckSequence);

--- a/PacketDotNet/Ieee80211/NullDataFrame.cs
+++ b/PacketDotNet/Ieee80211/NullDataFrame.cs
@@ -40,12 +40,12 @@ namespace PacketDotNet
             /// This does not include the FCS, it represents only the header bytes that would
             /// would preceed any payload.
             /// </summary>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {
                     //if we are in WDS mode then there are 4 addresses (normally it is just 3)
-                    int numOfAddressFields = (FrameControl.ToDS && FrameControl.FromDS) ? 4 : 3;
+                    Int32 numOfAddressFields = (FrameControl.ToDS && FrameControl.FromDS) ? 4 : 3;
 
                     return (MacFields.FrameControlLength +
                         MacFields.DurationIDLength +

--- a/PacketDotNet/Ieee80211/PpiFields.cs
+++ b/PacketDotNet/Ieee80211/PpiFields.cs
@@ -85,7 +85,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override int Length { get {return 8; } }
+            public override Int32 Length { get {return 8; } }
             
             /// <summary>
             /// Gets or sets the standard 802.2 flags.
@@ -108,14 +108,14 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public override byte[] Bytes
+            public override Byte[] Bytes
             {
                 get
                 {
                     MemoryStream ms = new MemoryStream();
                     BinaryWriter writer = new BinaryWriter(ms);
-                    writer.Write((uint)Flags);
-                    writer.Write((uint)Errors);
+                    writer.Write((UInt32)Flags);
+                    writer.Write((UInt32)Errors);
                     return ms.ToArray();
                 }
             }
@@ -186,7 +186,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override int Length { get {return 4; } }
+            public override Int32 Length { get {return 4; } }
    
             /// <summary>
             /// Zero-based index of the physical interface the packet was captured from.
@@ -194,7 +194,7 @@ namespace PacketDotNet
             /// <value>
             /// The interface id.
             /// </value>
-            public uint InterfaceId { get; set; }
+            public UInt32 InterfaceId { get; set; }
             
             /// <summary>
             /// Gets the field bytes. This doesn't include the PPI field header.
@@ -202,7 +202,7 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public override byte[] Bytes
+            public override Byte[] Bytes
             {
                 get
                 {
@@ -236,7 +236,7 @@ namespace PacketDotNet
             /// <param name='InterfaceId'>
             /// The interface id.
             /// </param>
-            public PpiAggregation(uint InterfaceId)
+            public PpiAggregation(UInt32 InterfaceId)
             {
                 this.InterfaceId = InterfaceId;
             }
@@ -272,7 +272,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override int Length { get { return 0; } }
+            public override Int32 Length { get { return 0; } }
             
             /// <summary>
             /// Gets the field bytes. This doesn't include the PPI field header.
@@ -280,11 +280,11 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public override byte[] Bytes
+            public override Byte[] Bytes
             {
                 get
                 {
-                    return new byte[0];
+                    return new Byte[0];
                 }
             }
 
@@ -361,7 +361,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override int Length { get { return 20; } }
+            public override Int32 Length { get { return 20; } }
             
             /// <summary>
             /// Radiotap-formatted channel flags.
@@ -387,7 +387,7 @@ namespace PacketDotNet
             /// <value>
             /// The data rate.
             /// </value>
-            public double Rate { get; set; } 
+            public Double Rate { get; set; } 
    
             /// <summary>
             /// Gets or sets the TSF timer.
@@ -439,7 +439,7 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public override byte[] Bytes
+            public override Byte[] Bytes
             {
                 get
                 {
@@ -447,10 +447,10 @@ namespace PacketDotNet
                     BinaryWriter writer = new BinaryWriter(ms);
                     
                     writer.Write(TSFTimer);
-                    writer.Write((ushort)Flags);
-                    writer.Write((ushort)(Rate * 2));
+                    writer.Write((UInt16)Flags);
+                    writer.Write((UInt16)(Rate * 2));
                     writer.Write(ChannelFrequency);
-                    writer.Write((ushort)ChannelFlags);
+                    writer.Write((UInt16)ChannelFlags);
                     writer.Write(FhssHopset);
                     writer.Write(FhssPattern);
                     writer.Write(AntennaSignalPower);
@@ -521,7 +521,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public abstract int Length { get; }
+            public abstract Int32 Length { get; }
             
             /// <summary>
             /// Gets the field bytes. This doesn't include the PPI field header.
@@ -529,7 +529,7 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public abstract byte[] Bytes { get; }
+            public abstract Byte[] Bytes { get; }
             
         #endregion Properties
 
@@ -550,7 +550,7 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="PpiField"/>
             /// </returns>
-            public static PpiField Parse (int fieldType, BinaryReader br, ushort fieldLength)
+            public static PpiField Parse (Int32 fieldType, BinaryReader br, UInt16 fieldLength)
             {
                 var type = (PpiFieldType)fieldType;
                 switch (type)
@@ -640,7 +640,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override int Length { get { return 12; } }
+            public override Int32 Length { get { return 12; } }
             
             /// <summary>
             /// Gets or sets the 802.11n MAC extension flags.
@@ -655,14 +655,14 @@ namespace PacketDotNet
             /// <value>
             /// the A-MPDU id.
             /// </value>
-            public uint AMpduId { get; set; }
+            public UInt32 AMpduId { get; set; }
             /// <summary>
             /// Gets or sets the number of zero-length pad delimiters
             /// </summary>
             /// <value>
             /// The delimiter count.
             /// </value>
-            public byte DelimiterCount { get; set; }
+            public Byte DelimiterCount { get; set; }
             
             /// <summary>
             /// Gets the field bytes. This doesn't include the PPI field header.
@@ -670,17 +670,17 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public override byte[] Bytes
+            public override Byte[] Bytes
             {
                 get
                 {
                     MemoryStream ms = new MemoryStream();
                     BinaryWriter writer = new BinaryWriter(ms);
                     
-                    writer.Write((uint) Flags);
+                    writer.Write((UInt32) Flags);
                     writer.Write(AMpduId);
                     writer.Write(DelimiterCount);
-                    writer.Write(new byte[3]);
+                    writer.Write(new Byte[3]);
                     
                     return ms.ToArray();
                 }
@@ -739,7 +739,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override int Length { get { return 48; } }
+            public override Int32 Length { get { return 48; } }
             
             /// <summary>
             /// Gets or sets the 802.11n MAC extension flags.
@@ -754,28 +754,28 @@ namespace PacketDotNet
             /// <value>
             /// the A-MPDU id.
             /// </value>
-            public uint AMpduId { get; set; }
+            public UInt32 AMpduId { get; set; }
             /// <summary>
             /// Gets or sets the number of zero-length pad delimiters
             /// </summary>
             /// <value>
             /// The delimiter count.
             /// </value>
-            public byte DelimiterCount { get; set; }
+            public Byte DelimiterCount { get; set; }
             /// <summary>
             /// Gets or sets the modulation coding scheme.
             /// </summary>
             /// <value>
             /// The modulation coding scheme.
             /// </value>
-            public byte ModulationCodingScheme { get; set; }
+            public Byte ModulationCodingScheme { get; set; }
             /// <summary>
             /// Gets or sets the number of spatial streams.
             /// </summary>
             /// <value>
             /// The spatial stream count.
             /// </value>
-            public byte SpatialStreamCount { get; set; }
+            public Byte SpatialStreamCount { get; set; }
             /// <summary>
             /// Gets or sets the combined Received Signal Strength Indication (RSSI) value 
             /// from all the active antennas and channels.
@@ -783,70 +783,70 @@ namespace PacketDotNet
             /// <value>
             /// The combined RSSI.
             /// </value>
-            public byte RssiCombined { get; set; }
+            public Byte RssiCombined { get; set; }
             /// <summary>
             /// Gets or sets the Received Signal Strength Indication (RSSI) value for the antenna 0, control channel.
             /// </summary>
             /// <value>
             /// The antenna 0 RSSI value.
             /// </value>
-            public byte RssiAntenna0Control { get; set; }
+            public Byte RssiAntenna0Control { get; set; }
             /// <summary>
             /// Gets or sets the Received Signal Strength Indication (RSSI) value for the antenna 1, control channel.
             /// </summary>
             /// <value>
             /// The antenna 1 control channel RSSI value.
             /// </value>
-            public byte RssiAntenna1Control { get; set; }
+            public Byte RssiAntenna1Control { get; set; }
             /// <summary>
             /// Gets or sets the Received Signal Strength Indication (RSSI) value for the antenna 2, control channel.
             /// </summary>
             /// <value>
             /// The antenna 2 control channel RSSI value.
             /// </value>
-            public byte RssiAntenna2Control { get; set; }
+            public Byte RssiAntenna2Control { get; set; }
             /// <summary>
             /// Gets or sets the Received Signal Strength Indication (RSSI) value for the antenna 3, control channel.
             /// </summary>
             /// <value>
             /// The antenna 3 control channel RSSI value.
             /// </value>
-            public byte RssiAntenna3Control { get; set; }
+            public Byte RssiAntenna3Control { get; set; }
             /// <summary>
             /// Gets or sets the Received Signal Strength Indication (RSSI) value for the antenna 0, extension channel
             /// </summary>
             /// <value>
             /// The antenna 0 extension channel RSSI value.
             /// </value>
-            public byte RssiAntenna0Ext { get; set; }
+            public Byte RssiAntenna0Ext { get; set; }
             /// <summary>
             /// Gets or sets the Received Signal Strength Indication (RSSI) value for the antenna 1, extension channel
             /// </summary>
             /// <value>
             /// The antenna 1 extension channel RSSI value.
             /// </value>
-            public byte RssiAntenna1Ext { get; set; }
+            public Byte RssiAntenna1Ext { get; set; }
             /// <summary>
             /// Gets or sets the Received Signal Strength Indication (RSSI) value for the antenna 2, extension channel
             /// </summary>
             /// <value>
             /// The antenna 2 extension channel RSSI value.
             /// </value>
-            public byte RssiAntenna2Ext { get; set; }
+            public Byte RssiAntenna2Ext { get; set; }
             /// <summary>
             /// Gets or sets the Received Signal Strength Indication (RSSI) value for the antenna 3, extension channel
             /// </summary>
             /// <value>
             /// The antenna 3 extension channel RSSI value.
             /// </value>
-            public byte RssiAntenna3Ext { get; set; }
+            public Byte RssiAntenna3Ext { get; set; }
             /// <summary>
             /// Gets or sets the extension channel frequency.
             /// </summary>
             /// <value>
             /// The extension channel frequency.
             /// </value>
-            public ushort ExtensionChannelFrequency { get; set; }
+            public UInt16 ExtensionChannelFrequency { get; set; }
             /// <summary>
             /// Gets or sets the extension channel flags.
             /// </summary>
@@ -860,84 +860,84 @@ namespace PacketDotNet
             /// <value>
             /// The signal power.
             /// </value>
-            public byte DBmAntenna0SignalPower { get; set; }
+            public Byte DBmAntenna0SignalPower { get; set; }
             /// <summary>
             /// Gets or sets the RF signal noise at antenna 0.
             /// </summary>
             /// <value>
             /// The signal noise.
             /// </value>
-            public byte DBmAntenna0SignalNoise { get; set; }
+            public Byte DBmAntenna0SignalNoise { get; set; }
             /// <summary>
             /// Gets or sets the RF signal power at antenna 1.
             /// </summary>
             /// <value>
             /// The signal power.
             /// </value>
-            public byte DBmAntenna1SignalPower { get; set; }
+            public Byte DBmAntenna1SignalPower { get; set; }
             /// <summary>
             /// Gets or sets the RF signal noise at antenna 1.
             /// </summary>
             /// <value>
             /// The signal noise.
             /// </value>
-            public byte DBmAntenna1SignalNoise { get; set; }
+            public Byte DBmAntenna1SignalNoise { get; set; }
             /// <summary>
             /// Gets or sets the RF signal power at antenna 2.
             /// </summary>
             /// <value>
             /// The signal power.
             /// </value>
-            public byte DBmAntenna2SignalPower { get; set; }
+            public Byte DBmAntenna2SignalPower { get; set; }
             /// <summary>
             /// Gets or sets the RF signal noise at antenna 2.
             /// </summary>
             /// <value>
             /// The signal noise.
             /// </value>
-            public byte DBmAntenna2SignalNoise { get; set; }
+            public Byte DBmAntenna2SignalNoise { get; set; }
             /// <summary>
             /// Gets or sets the RF signal power at antenna 3.
             /// </summary>
             /// <value>
             /// The signal power.
             /// </value>
-            public byte DBmAntenna3SignalPower { get; set; }
+            public Byte DBmAntenna3SignalPower { get; set; }
             /// <summary>
             /// Gets or sets the RF signal noise at antenna 3.
             /// </summary>
             /// <value>
             /// The signal noise.
             /// </value>
-            public byte DBmAntenna3SignalNoise { get; set; }
+            public Byte DBmAntenna3SignalNoise { get; set; }
             /// <summary>
             /// Gets or sets the error vector magnitude for Chain 0.
             /// </summary>
             /// <value>
             /// The error vector magnitude.
             /// </value>
-            public uint ErrorVectorMagnitude0 { get; set; }
+            public UInt32 ErrorVectorMagnitude0 { get; set; }
             /// <summary>
             /// Gets or sets the error vector magnitude for Chain 1.
             /// </summary>
             /// <value>
             /// The error vector magnitude.
             /// </value>
-            public uint ErrorVectorMagnitude1 { get; set; }
+            public UInt32 ErrorVectorMagnitude1 { get; set; }
             /// <summary>
             /// Gets or sets the error vector magnitude for Chain 2.
             /// </summary>
             /// <value>
             /// The error vector magnitude.
             /// </value>
-            public uint ErrorVectorMagnitude2 { get; set; }
+            public UInt32 ErrorVectorMagnitude2 { get; set; }
             /// <summary>
             /// Gets or sets the error vector magnitude for Chain 3.
             /// </summary>
             /// <value>
             /// The error vector magnitude.
             /// </value>
-            public uint ErrorVectorMagnitude3 { get; set; }
+            public UInt32 ErrorVectorMagnitude3 { get; set; }
             
             /// <summary>
             /// Gets the field bytes. This doesn't include the PPI field header.
@@ -945,7 +945,7 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public override byte[] Bytes
+            public override Byte[] Bytes
             {
                 get
                 {
@@ -966,7 +966,7 @@ namespace PacketDotNet
                     writer.Write(RssiAntenna2Ext);
                     writer.Write(RssiAntenna3Ext);
                     writer.Write(ExtensionChannelFrequency);
-                    writer.Write((ushort)ExtensionChannelFlags);
+                    writer.Write((UInt16)ExtensionChannelFlags);
                     writer.Write(DBmAntenna0SignalPower);
                     writer.Write(DBmAntenna0SignalNoise);
                     writer.Write(DBmAntenna1SignalPower);
@@ -1059,7 +1059,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override int Length
+            public override Int32 Length
             {
                 get
                 {
@@ -1076,14 +1076,14 @@ namespace PacketDotNet
             /// <value>
             /// The process identifier.
             /// </value>
-            public uint ProcessId { get; set; }
+            public UInt32 ProcessId { get; set; }
             /// <summary>
             /// Gets or sets the thread identifier.
             /// </summary>
             /// <value>
             /// The thread identifier.
             /// </value>
-            public uint ThreadId { get; set; }
+            public UInt32 ThreadId { get; set; }
             /// <summary>
             /// Gets or sets the process path.
             /// </summary>
@@ -1097,7 +1097,7 @@ namespace PacketDotNet
             /// <value>
             /// The user identifier.
             /// </value>
-            public uint UserId { get; set; }
+            public UInt32 UserId { get; set; }
             /// <summary>
             /// Gets or sets the user name.
             /// </summary>
@@ -1111,7 +1111,7 @@ namespace PacketDotNet
             /// <value>
             /// The group identifier.
             /// </value>
-            public uint GroupId { get; set; }
+            public UInt32 GroupId { get; set; }
             /// <summary>
             /// Gets or sets the group name.
             /// </summary>
@@ -1126,7 +1126,7 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public override byte[] Bytes
+            public override Byte[] Bytes
             {
                 get
                 {
@@ -1137,19 +1137,19 @@ namespace PacketDotNet
                     writer.Write(ThreadId);
                     
                     var pathBytes = Encoding.UTF8.GetBytes(ProcessPath ?? String.Empty);
-                    writer.Write((byte)pathBytes.Length);
+                    writer.Write((Byte)pathBytes.Length);
                     writer.Write(pathBytes);
                     
                     writer.Write(UserId);
                     
                     var userBytes = Encoding.UTF8.GetBytes(UserName ?? String.Empty);
-                    writer.Write((byte)userBytes.Length);
+                    writer.Write((Byte)userBytes.Length);
                     writer.Write(userBytes);
                     
                     writer.Write(GroupId);
                     
                     var groupBytes = Encoding.UTF8.GetBytes(GroupName ?? String.Empty);
-                    writer.Write((byte)groupBytes.Length);
+                    writer.Write((Byte)groupBytes.Length);
                     writer.Write(groupBytes);
                         
                     return ms.ToArray();
@@ -1220,7 +1220,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override int Length { get { return Bytes.Length; } }
+            public override Int32 Length { get { return Bytes.Length; } }
    
             /// <summary>
             /// Gets the field bytes. This doesn't include the PPI field header.
@@ -1228,14 +1228,14 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public override byte[] Bytes { get { return UnknownBytes; } }
+            public override Byte[] Bytes { get { return UnknownBytes; } }
             /// <summary>
             /// Gets or sets the field data.
             /// </summary>
             /// <value>
             /// The fields values bytes.
             /// </value>
-            public byte[] UnknownBytes { get; set; }
+            public Byte[] UnknownBytes { get; set; }
             
         #endregion Properties
 
@@ -1257,7 +1257,7 @@ namespace PacketDotNet
             /// <param name='length'>
             /// The number of bytes the unknown field contains.
             /// </param>
-            public PpiUnknown (int typeNumber, BinaryReader br, int length)
+            public PpiUnknown (Int32 typeNumber, BinaryReader br, Int32 length)
             {
                 fieldType = (PpiFieldType) typeNumber;
                 UnknownBytes = br.ReadBytes(length);
@@ -1269,7 +1269,7 @@ namespace PacketDotNet
             /// <param name='typeNumber'>
             /// The PPI field type number.
             /// </param>
-            public PpiUnknown (int typeNumber)
+            public PpiUnknown (Int32 typeNumber)
             {
                 fieldType = (PpiFieldType)typeNumber;
             }
@@ -1282,7 +1282,7 @@ namespace PacketDotNet
             /// <param name='UnknownBytes'>
             /// The field data.
             /// </param>
-            public PpiUnknown (int typeNumber, byte[] UnknownBytes)
+            public PpiUnknown (Int32 typeNumber, Byte[] UnknownBytes)
             {
                 fieldType = (PpiFieldType)typeNumber;
                 this.UnknownBytes = UnknownBytes;
@@ -1311,49 +1311,49 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override int Length { get { return 20 + SamplesData.Length; } }
+            public override Int32 Length { get { return 20 + SamplesData.Length; } }
             /// <summary>
             /// Gets or sets the starting frequency in kHz.
             /// </summary>
             /// <value>
             /// The starting frequency.
             /// </value>
-            public uint StartingFrequency { get; set; }
+            public UInt32 StartingFrequency { get; set; }
             /// <summary>
             /// Gets or sets the resolution of each sample in Hz.
             /// </summary>
             /// <value>
             /// The resolution in Hz.
             /// </value>
-            public uint Resolution { get; set; }
+            public UInt32 Resolution { get; set; }
             /// <summary>
             /// Gets or sets the amplitude offset (in 0.001 dBm)
             /// </summary>
             /// <value>
             /// The amplitude offset.
             /// </value>
-            public uint AmplitudeOffset { get; set; }
+            public UInt32 AmplitudeOffset { get; set; }
             /// <summary>
             /// Gets or sets the amplitude resolution (in .001 dBm)
             /// </summary>
             /// <value>
             /// The amplitude resolution.
             /// </value>
-            public uint AmplitudeResolution { get; set; }
+            public UInt32 AmplitudeResolution { get; set; }
             /// <summary>
             /// Gets or sets the maximum raw RSSI value reported by the device.
             /// </summary>
             /// <value>
             /// The maximum rssi.
             /// </value>
-            public ushort MaximumRssi { get; set; }
+            public UInt16 MaximumRssi { get; set; }
             /// <summary>
             /// Gets or sets the data samples.
             /// </summary>
             /// <value>
             /// The data samples.
             /// </value>
-            public byte[] SamplesData { get; set;}
+            public Byte[] SamplesData { get; set;}
             
             /// <summary>
             /// Gets the field bytes. This doesn't include the PPI field header.
@@ -1361,7 +1361,7 @@ namespace PacketDotNet
             /// <value>
             /// The bytes.
             /// </value>
-            public override byte[] Bytes
+            public override Byte[] Bytes
             {
                 get
                 {
@@ -1373,7 +1373,7 @@ namespace PacketDotNet
                     writer.Write(AmplitudeOffset);
                     writer.Write(AmplitudeResolution);
                     writer.Write(MaximumRssi);
-                    writer.Write((ushort) SamplesData.Length);
+                    writer.Write((UInt16) SamplesData.Length);
                     writer.Write(SamplesData);
                     
                     return ms.ToArray();

--- a/PacketDotNet/Ieee80211/PpiHeaderFields.cs
+++ b/PacketDotNet/Ieee80211/PpiHeaderFields.cs
@@ -38,37 +38,37 @@ namespace PacketDotNet
         #region Fields
             
             /// <summary>Position of the first iField Header</summary>
-            public static readonly int FirstFieldPosition;
+            public static readonly Int32 FirstFieldPosition;
 
             /// <summary>Length of the Data Link Type</summary>
-            public static readonly int DataLinkTypeLength = 4;
+            public static readonly Int32 DataLinkTypeLength = 4;
    
             /// <summary>The data link type position.</summary>
-            public static readonly int DataLinkTypePosition;
+            public static readonly Int32 DataLinkTypePosition;
             
             /// <summary>Length of the Flags field</summary>
-            public static readonly int FlagsLength = 1;
+            public static readonly Int32 FlagsLength = 1;
 
             /// <summary>Position of the Flags field</summary>
-            public static readonly int FlagsPosition;
+            public static readonly Int32 FlagsPosition;
 
             /// <summary>Length of the length field</summary>
-            public static readonly int LengthLength = 2;
+            public static readonly Int32 LengthLength = 2;
 
             /// <summary>Position of the length field</summary>
-            public static readonly int LengthPosition;
+            public static readonly Int32 LengthPosition;
 
             /// <summary>Length of the version field</summary>
-            public static readonly int VersionLength = 1;
+            public static readonly Int32 VersionLength = 1;
 
             /// <summary>Position of the version field</summary>
-            public static readonly int VersionPosition = 0;
+            public static readonly Int32 VersionPosition = 0;
             
             /// <summary>The total length of the ppi packet header</summary>
-            public static readonly int PpiPacketHeaderLength;
+            public static readonly Int32 PpiPacketHeaderLength;
             
             /// <summary>The length of the PPI field header</summary>
-            public static readonly int FieldHeaderLength = 4;
+            public static readonly Int32 FieldHeaderLength = 4;
             
         #endregion Fields
 

--- a/PacketDotNet/Ieee80211/PpiPacket.cs
+++ b/PacketDotNet/Ieee80211/PpiPacket.cs
@@ -100,9 +100,9 @@ namespace PacketDotNet
             /// Version 0. Only increases for drastic changes, introduction of compatible
             /// new fields does not count.
             /// </summary>
-            public byte Version { get; set; }
+            public Byte Version { get; set; }
             
-            private byte VersionBytes
+            private Byte VersionBytes
             {
                 get
                 {
@@ -132,7 +132,7 @@ namespace PacketDotNet
                 
                 set
                 {
-                    header.Bytes[header.Offset + PpiHeaderFields.FlagsPosition] = (byte) value;
+                    header.Bytes[header.Offset + PpiHeaderFields.FlagsPosition] = (Byte) value;
                 }
             }
             
@@ -155,7 +155,7 @@ namespace PacketDotNet
                 
                 set
                 {
-                    EndianBitConverter.Little.CopyBytes((uint)LinkType,
+                    EndianBitConverter.Little.CopyBytes((UInt32)LinkType,
                                                      header.Bytes,
                                                      header.Offset + PpiHeaderFields.DataLinkTypePosition);
                 }
@@ -167,14 +167,14 @@ namespace PacketDotNet
             /// <value>
             /// The number of fields.
             /// </value>
-            public int Count { get { return PpiFields.Count; } } 
+            public Int32 Count { get { return PpiFields.Count; } } 
             /// <summary>
             /// Gets the <see cref="PacketDotNet.Ieee80211.PpiPacket"/> at the specified index.
             /// </summary>
             /// <param name='index'>
             /// Index.
             /// </param>
-            public PpiField this[int index]
+            public PpiField this[Int32 index]
             {
                 get
                 {
@@ -264,7 +264,7 @@ namespace PacketDotNet
             /// <param name='field'>
             /// <c>true</c> if the field is in the packet, <c>false</c> if not.
             /// </param>
-            public bool Contains(PpiField field)
+            public Boolean Contains(PpiField field)
             {
                 return PpiFields.Contains(field);
             }
@@ -275,7 +275,7 @@ namespace PacketDotNet
             /// <param name='type'>
             /// <c>true</c> if there is a field of the specified type in the packet, <c>false</c> if not.
             /// </param>
-            public bool Contains(PpiFieldType type)
+            public Boolean Contains(PpiFieldType type)
             {
                 return (PpiFields.Find(field => field.FieldType == type) != null);
             }
@@ -315,11 +315,11 @@ namespace PacketDotNet
             }
 
             /// <summary cref="Packet.ToString(StringOutputType)" />
-            public override string ToString (StringOutputType outputFormat)
+            public override String ToString (StringOutputType outputFormat)
             {
                 var buffer = new StringBuilder ();
-                string color = "";
-                string colorEscape = "";
+                String color = "";
+                String colorEscape = "";
 
                 if (outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
                 {
@@ -341,7 +341,7 @@ namespace PacketDotNet
                 if (outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
                 {
                     // collect the properties and their value
-                    var properties = new Dictionary<string, string> ();
+                    var properties = new Dictionary<String, String> ();
                     properties.Add ("version", Version.ToString ());
                     properties.Add ("length", Length.ToString ());
 
@@ -354,7 +354,7 @@ namespace PacketDotNet
                     }
 
                     // calculate the padding needed to right-justify the property names
-                    int padLength = RandomUtils.LongestStringLength (new List<string> (properties.Keys));
+                    Int32 padLength = RandomUtils.LongestStringLength (new List<String> (properties.Keys));
 
                     // build the output string
                     buffer.AppendLine ("Ieee80211PpiPacket");
@@ -390,7 +390,7 @@ namespace PacketDotNet
             {
                 //If aligned is true then fields must all start on 32bit boundaries so we might need
                 //to read some extra padding from the end of the header fields.
-                bool aligned = ((Flags & HeaderFlags.Alignment32Bit) == HeaderFlags.Alignment32Bit);
+                Boolean aligned = ((Flags & HeaderFlags.Alignment32Bit) == HeaderFlags.Alignment32Bit);
                 
                 var totalFieldLength = Length;
              
@@ -403,7 +403,7 @@ namespace PacketDotNet
                 
                 VersionBytes = Version;
                 FlagsBytes = Flags;
-                LengthBytes = (ushort)totalFieldLength;
+                LengthBytes = (UInt16)totalFieldLength;
                 LinkTypeBytes = LinkType;
                 
                 MemoryStream ms = new MemoryStream(header.Bytes,
@@ -412,13 +412,13 @@ namespace PacketDotNet
                 BinaryWriter writer = new BinaryWriter(ms);
                 foreach (var field in PpiFields)
                 {
-                    writer.Write((ushort) field.FieldType);
-                    writer.Write((ushort) field.Length);
+                    writer.Write((UInt16) field.FieldType);
+                    writer.Write((UInt16) field.Length);
                     writer.Write(field.Bytes);
                     var paddingBytesRequired = GetDistanceTo32BitAlignment(field.Length);
                     if(aligned && (paddingBytesRequired > 0))
                     {
-                        writer.Write(new byte[paddingBytesRequired]);
+                        writer.Write(new Byte[paddingBytesRequired]);
                     }
                 }
             }
@@ -434,7 +434,7 @@ namespace PacketDotNet
             {
                 //If aligned is true then fields must all start on 32bit boundaries so we might need
                 //to read some extra padding from the end of the header fields.
-                bool aligned = ((Flags & HeaderFlags.Alignment32Bit) == HeaderFlags.Alignment32Bit);
+                Boolean aligned = ((Flags & HeaderFlags.Alignment32Bit) == HeaderFlags.Alignment32Bit);
                 
                 var retList = new List<PpiField> ();
 
@@ -442,9 +442,9 @@ namespace PacketDotNet
                 var offset = header.Offset + PpiHeaderFields.FirstFieldPosition;
                 var br = new BinaryReader (new MemoryStream (header.Bytes,
                                                        offset,
-                                                       (int)(header.Length - offset)));
-                int type = 0;
-                int length = PpiHeaderFields.FirstFieldPosition;
+                                                       (Int32)(header.Length - offset)));
+                Int32 type = 0;
+                Int32 length = PpiHeaderFields.FirstFieldPosition;
                 while(length < header.Length)
                 {
                     type = br.ReadUInt16 ();
@@ -484,7 +484,7 @@ namespace PacketDotNet
                 
                 if (commonField != null)
                 {
-                    bool fcsPresent = ((commonField.Flags & PpiCommon.CommonFlags.FcsIncludedInFrame) == PpiCommon.CommonFlags.FcsIncludedInFrame);
+                    Boolean fcsPresent = ((commonField.Flags & PpiCommon.CommonFlags.FcsIncludedInFrame) == PpiCommon.CommonFlags.FcsIncludedInFrame);
                     
                     if (fcsPresent)
                     {
@@ -512,7 +512,7 @@ namespace PacketDotNet
                 return payloadPacketOrData;
             }
    
-            private int GetDistanceTo32BitAlignment(int length)
+            private Int32 GetDistanceTo32BitAlignment(Int32 length)
             {
                 return ((length % 4) == 0) ? 0 : 4 - (length % 4);
             }

--- a/PacketDotNet/Ieee80211/ProbeRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/ProbeRequestFrame.cs
@@ -36,7 +36,7 @@ namespace PacketDotNet
         {
             private class ProbeRequestFields
             {
-                public readonly static int InformationElement1Position;
+                public readonly static Int32 InformationElement1Position;
 
                 static ProbeRequestFields()
                 {
@@ -50,7 +50,7 @@ namespace PacketDotNet
             /// This does not include the FCS, it represents only the header bytes that would
             /// would preceed any payload.
             /// </summary>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/ProbeResponseFrame.cs
+++ b/PacketDotNet/Ieee80211/ProbeResponseFrame.cs
@@ -39,14 +39,14 @@ namespace PacketDotNet
         {
             private class ProbeResponseFields
             {
-                public readonly static int TimestampLength = 8;
-                public readonly static int BeaconIntervalLength = 2;
-                public readonly static int CapabilityInformationLength = 2;
+                public readonly static Int32 TimestampLength = 8;
+                public readonly static Int32 BeaconIntervalLength = 2;
+                public readonly static Int32 CapabilityInformationLength = 2;
 
-                public readonly static int TimestampPosition;
-                public readonly static int BeaconIntervalPosition;
-                public readonly static int CapabilityInformationPosition;
-                public readonly static int InformationElement1Position;
+                public readonly static Int32 TimestampPosition;
+                public readonly static Int32 BeaconIntervalPosition;
+                public readonly static Int32 CapabilityInformationPosition;
+                public readonly static Int32 InformationElement1Position;
 
                 static ProbeResponseFields()
                 {
@@ -164,7 +164,7 @@ namespace PacketDotNet
             /// This does not include the FCS, it represents only the header bytes that would
             /// would preceed any payload.
             /// </summary>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/QosDataFrame.cs
+++ b/PacketDotNet/Ieee80211/QosDataFrame.cs
@@ -47,9 +47,9 @@ namespace PacketDotNet
 
             private class QosDataField
             {
-                public readonly static int QosControlLength = 2;
+                public readonly static Int32 QosControlLength = 2;
 
-                public readonly static int QosControlPosition;
+                public readonly static Int32 QosControlPosition;
 
                 static QosDataField()
                 {
@@ -94,12 +94,12 @@ namespace PacketDotNet
             /// This does not include the FCS, it represents only the header bytes that would
             /// would preceed any payload.
             /// </summary>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {
                     //if we are in WDS mode then there are 4 addresses (normally it is just 3)
-                    int numOfAddressFields = (FrameControl.ToDS && FrameControl.FromDS) ? 4 : 3;
+                    Int32 numOfAddressFields = (FrameControl.ToDS && FrameControl.FromDS) ? 4 : 3;
 
                     return (MacFields.FrameControlLength +
                         MacFields.DurationIDLength +

--- a/PacketDotNet/Ieee80211/QosNullDataFrame.cs
+++ b/PacketDotNet/Ieee80211/QosNullDataFrame.cs
@@ -36,9 +36,9 @@ namespace PacketDotNet
         {
             private class QosNullDataField
             {
-                public readonly static int QosControlLength = 2;
+                public readonly static Int32 QosControlLength = 2;
 
-                public readonly static int QosControlPosition;
+                public readonly static Int32 QosControlPosition;
 
                 static QosNullDataField()
                 {
@@ -83,12 +83,12 @@ namespace PacketDotNet
             /// This does not include the FCS, it represents only the header bytes that would
             /// would preceed any payload.
             /// </summary>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {
                     //if we are in WDS mode then there are 4 addresses (normally it is just 3)
-                    int numOfAddressFields = (FrameControl.ToDS && FrameControl.FromDS) ? 4 : 3;
+                    Int32 numOfAddressFields = (FrameControl.ToDS && FrameControl.FromDS) ? 4 : 3;
 
                     return (MacFields.FrameControlLength +
                         MacFields.DurationIDLength +

--- a/PacketDotNet/Ieee80211/RadioFields.cs
+++ b/PacketDotNet/Ieee80211/RadioFields.cs
@@ -32,31 +32,31 @@ namespace PacketDotNet
         public class RadioFields
         {
             /// <summary>Length of the version field</summary>
-            public readonly static int VersionLength = 1;
+            public readonly static Int32 VersionLength = 1;
 
             /// <summary>Length of the pad field</summary>
-            public readonly static int PadLength = 1;
+            public readonly static Int32 PadLength = 1;
 
             /// <summary>Length of the length field</summary>
-            public readonly static int LengthLength = 2;
+            public readonly static Int32 LengthLength = 2;
 
             /// <summary>Length of the first present field (others may follow)</summary>
-            public readonly static int PresentLength = 4;
+            public readonly static Int32 PresentLength = 4;
 
             /// <summary>Position of the version field</summary>
-            public readonly static int VersionPosition = 0;
+            public readonly static Int32 VersionPosition = 0;
 
             /// <summary>Position of the padding field</summary>
-            public readonly static int PadPosition;
+            public readonly static Int32 PadPosition;
 
             /// <summary>Position of the length field</summary>
-            public readonly static int LengthPosition;
+            public readonly static Int32 LengthPosition;
 
             /// <summary>Position of the first present field</summary>
-            public readonly static int PresentPosition;
+            public readonly static Int32 PresentPosition;
 
             /// <summary>Default header length, assuming one present field entry</summary>
-            public readonly static int DefaultHeaderLength;
+            public readonly static Int32 DefaultHeaderLength;
 
             static RadioFields()
             {

--- a/PacketDotNet/Ieee80211/RadioPacket.cs
+++ b/PacketDotNet/Ieee80211/RadioPacket.cs
@@ -51,9 +51,9 @@ namespace PacketDotNet
             /// Version 0. Only increases for drastic changes, introduction of compatible
             /// new fields does not count.
             /// </summary>
-            public byte Version { get; set; }
+            public Byte Version { get; set; }
             
-            private byte VersionBytes
+            private Byte VersionBytes
             {
                 get
                 {
@@ -105,7 +105,7 @@ namespace PacketDotNet
                 UInt32 bitmask = EndianBitConverter.Little.ToUInt32(header.Bytes,
                                                                     header.Offset + RadioFields.PresentPosition);
                 bitmaskFields.Add(bitmask);
-                int bitmaskOffsetInBytes = 4;
+                Int32 bitmaskOffsetInBytes = 4;
                 while ((bitmask & (1 << 31)) == 1)
                 {
                     // retrieve the next field
@@ -125,7 +125,7 @@ namespace PacketDotNet
             {
                 Present = new UInt32[1];
                 RadioTapFields = new SortedDictionary<RadioTapType, RadioTapField>();
-                Length = (ushort)RadioFields.DefaultHeaderLength;
+                Length = (UInt16)RadioFields.DefaultHeaderLength;
             }
             
             internal RadioPacket (ByteArraySegment bas)
@@ -150,11 +150,11 @@ namespace PacketDotNet
             }
 
             /// <summary cref="Packet.ToString(StringOutputType)" />
-            public override string ToString(StringOutputType outputFormat)
+            public override String ToString(StringOutputType outputFormat)
             {
                 var buffer = new StringBuilder();
-                string color = "";
-                string colorEscape = "";
+                String color = "";
+                String colorEscape = "";
 
                 if (outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
                 {
@@ -176,7 +176,7 @@ namespace PacketDotNet
                 if (outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
                 {
                     // collect the properties and their value
-                    Dictionary<string, string> properties = new Dictionary<string, string>();
+                    Dictionary<String, String> properties = new Dictionary<String, String>();
                     properties.Add("version", Version.ToString());
                     properties.Add("length", Length.ToString());
                     properties.Add("present", " (0x" + Present[0].ToString("x") + ")");
@@ -190,7 +190,7 @@ namespace PacketDotNet
                     }
 
                     // calculate the padding needed to right-justify the property names
-                    int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                    Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                     // build the output string
                     buffer.AppendLine("Ieee80211RadioPacket");
@@ -217,14 +217,14 @@ namespace PacketDotNet
             {
                 RadioTapFields[field.FieldType] = field;
                 Length += field.Length;
-                var presenceBit = (int)field.FieldType;
+                var presenceBit = (Int32)field.FieldType;
                 var presenceField = (presenceBit / 32);
                 if(Present.Length <= presenceField)
                 {
                     var newPresentFields = new UInt32[presenceField];
                     Array.Copy(Present, newPresentFields, Present.Length);
                     //set bit 31 to true for every present field except the last one
-                    for(int i = 0; i < newPresentFields.Length - 1; i++)
+                    for(Int32 i = 0; i < newPresentFields.Length - 1; i++)
                     {
                         newPresentFields[i] |= 0x80000000;
                     }
@@ -246,7 +246,7 @@ namespace PacketDotNet
                 {
                     RadioTapFields.Remove(fieldType);
                     Length -= field.Length;
-                    var presenceBit = (int)field.FieldType;
+                    var presenceBit = (Int32)field.FieldType;
                     var presenceField = (presenceBit / 32);
                     Present[presenceField] &= (UInt32)~(1 << presenceBit);
                 }
@@ -259,7 +259,7 @@ namespace PacketDotNet
             /// The field type to check for.
             /// </param>
             /// <returns><c>true</c> if the packet contains a field of the specified type; otherwise, <c>false</c>.</returns>
-            public bool Contains(RadioTapType fieldType)
+            public Boolean Contains(RadioTapType fieldType)
             {
                 return RadioTapFields.ContainsKey(fieldType);
             }
@@ -286,7 +286,7 @@ namespace PacketDotNet
             /// </summary>
             private SortedDictionary<RadioTapType, RadioTapField> RadioTapFields { get; set; }
             
-            private byte[] UnhandledFieldBytes {get; set;}
+            private Byte[] UnhandledFieldBytes {get; set;}
             
             private SortedDictionary<RadioTapType, RadioTapField> ReadRadioTapFields()
             {
@@ -294,7 +294,7 @@ namespace PacketDotNet
 
                 var retval = new SortedDictionary<RadioTapType, RadioTapField>();
 
-                int bitIndex = 0;
+                Int32 bitIndex = 0;
 
                 // create a binary reader that points to the memory immediately after the bitmasks
                 var offset = header.Offset +
@@ -302,21 +302,21 @@ namespace PacketDotNet
                              (bitmasks.Length) * Marshal.SizeOf (typeof(UInt32));
                 var br = new BinaryReader (new MemoryStream (header.Bytes,
                                                            offset,
-                                                           (int)(Length - offset)));
+                                                           (Int32)(Length - offset)));
 
                 // now go through each of the bitmask fields looking at the least significant
                 // bit first to retrieve each field
                 foreach (var bmask in bitmasks)
                 {
-                    int[] bmaskArray = new int[1];
-                    bmaskArray [0] = (int)bmask;
+                    Int32[] bmaskArray = new Int32[1];
+                    bmaskArray [0] = (Int32)bmask;
                     var ba = new BitArray (bmaskArray);
                     
-                    bool unhandledFieldFound = false;
+                    Boolean unhandledFieldFound = false;
 
                     // look at all of the bits, note we don't want to consider the
                     // highest bit since that indicates another bitfield that follows
-                    for (int x = 0; x < 31; x++)
+                    for (Int32 x = 0; x < 31; x++)
                     {
                         if (ba [x] == true)
                         {
@@ -393,7 +393,7 @@ namespace PacketDotNet
                 
                 if (flagsField != null)
                 {
-                    bool fcsPresent = ((flagsField.Flags & RadioTapFlags.FcsIncludedInFrame) == RadioTapFlags.FcsIncludedInFrame);
+                    Boolean fcsPresent = ((flagsField.Flags & RadioTapFlags.FcsIncludedInFrame) == RadioTapFlags.FcsIncludedInFrame);
                     
                     if (fcsPresent)
                     {

--- a/PacketDotNet/Ieee80211/RadioTapFields.cs
+++ b/PacketDotNet/Ieee80211/RadioTapFields.cs
@@ -42,7 +42,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 4; } }
+            public override UInt16 Length { get { return 4; } }
 
             /// <summary>
             /// Frequency in MHz
@@ -52,7 +52,7 @@ namespace PacketDotNet
             /// <summary>
             /// Channel number derived from frequency
             /// </summary>
-            public int Channel { get; set; }
+            public Int32 Channel { get; set; }
 
             /// <summary>
             /// Channel flags
@@ -70,7 +70,7 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.Int32"/>
             /// </returns>
-            public static int ChannelFromFrequencyMHz(int frequencyMHz)
+            public static Int32 ChannelFromFrequencyMHz(Int32 frequencyMHz)
             {
                 switch (frequencyMHz)
                 {
@@ -182,7 +182,7 @@ namespace PacketDotNet
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 EndianBitConverter.Little.CopyBytes(FrequencyMHz, dest, offset);
                 EndianBitConverter.Little.CopyBytes((UInt16)Flags, dest, offset + 2);
@@ -231,9 +231,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("FrequencyMHz {0}, Channel {1}, Flags {2}",
+                return String.Format("FrequencyMHz {0}, Channel {1}, Flags {2}",
                                      FrequencyMHz, Channel, Flags);
             }
         }
@@ -252,22 +252,22 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 2; } }
+            public override UInt16 Length { get { return 2; } }
             
             /// <summary>
             /// Hop set
             /// </summary>
-            public byte ChannelHoppingSet { get; set; }
+            public Byte ChannelHoppingSet { get; set; }
 
             /// <summary>
             /// Hop pattern
             /// </summary>
-            public byte Pattern { get; set; }
+            public Byte Pattern { get; set; }
             
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 dest[offset] = ChannelHoppingSet;
                 dest[offset + 1] = Pattern;
@@ -283,8 +283,8 @@ namespace PacketDotNet
             {
                 var u16 = br.ReadUInt16();
 
-                ChannelHoppingSet = (byte)(u16 & 0xff);
-                Pattern = (byte)((u16 >> 8) & 0xff);
+                ChannelHoppingSet = (Byte)(u16 & 0xff);
+                Pattern = (Byte)((u16 >> 8) & 0xff);
             }
    
             /// <summary>
@@ -304,7 +304,7 @@ namespace PacketDotNet
             /// <param name='Pattern'>
             /// Channel hopping pattern.
             /// </param>
-            public FhssRadioTapField(byte ChannelHoppingSet, byte Pattern)
+            public FhssRadioTapField(Byte ChannelHoppingSet, Byte Pattern)
             {
                 this.ChannelHoppingSet = ChannelHoppingSet;
                 this.Pattern = Pattern;
@@ -316,9 +316,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("ChannelHoppingSet {0}, Pattern {1}",
+                return String.Format("ChannelHoppingSet {0}, Pattern {1}",
                                      ChannelHoppingSet, Pattern);
             }
         }
@@ -337,7 +337,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 1; } }
+            public override UInt16 Length { get { return 1; } }
             
             /// <summary>
             /// Flags set
@@ -347,9 +347,9 @@ namespace PacketDotNet
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
-                dest[offset] = (byte) Flags;
+                dest[offset] = (Byte) Flags;
             }
 
             /// <summary>
@@ -389,9 +389,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("Flags {0}", Flags);
+                return String.Format("Flags {0}", Flags);
             }
         }
 
@@ -409,19 +409,19 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 1; } }
+            public override UInt16 Length { get { return 1; } }
             
             /// <summary>
             /// Rate in Mbps
             /// </summary>
-            public double RateMbps { get; set; }
+            public Double RateMbps { get; set; }
             
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
-                dest[offset] = (byte) (RateMbps / 0.5);
+                dest[offset] = (Byte) (RateMbps / 0.5);
             }
 
             /// <summary>
@@ -450,7 +450,7 @@ namespace PacketDotNet
             /// <param name='RateMbps'>
             /// Rate mbps.
             /// </param>
-            public RateRadioTapField(double RateMbps)
+            public RateRadioTapField(Double RateMbps)
             {
                 this.RateMbps = RateMbps;             
             }
@@ -461,9 +461,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("RateMbps {0}", RateMbps);
+                return String.Format("RateMbps {0}", RateMbps);
             }
         }
 
@@ -481,17 +481,17 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 1; } }
+            public override UInt16 Length { get { return 1; } }
             
             /// <summary>
             /// Signal strength in dB
             /// </summary>
-            public byte SignalStrengthdB { get; set; }
+            public Byte SignalStrengthdB { get; set; }
             
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 dest[offset] = SignalStrengthdB;
             }
@@ -521,7 +521,7 @@ namespace PacketDotNet
             /// <param name='SignalStrengthdB'>
             /// Signal strength in dB
             /// </param>
-            public DbAntennaSignalRadioTapField (byte SignalStrengthdB)
+            public DbAntennaSignalRadioTapField (Byte SignalStrengthdB)
             {
                 this.SignalStrengthdB = SignalStrengthdB;
             }
@@ -532,9 +532,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("SignalStrengthdB {0}", SignalStrengthdB);
+                return String.Format("SignalStrengthdB {0}", SignalStrengthdB);
             }
         }
 
@@ -552,17 +552,17 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 1; } }
+            public override UInt16 Length { get { return 1; } }
             
             /// <summary>
             /// Antenna noise in dB
             /// </summary>
-            public byte AntennaNoisedB { get; set; }
+            public Byte AntennaNoisedB { get; set; }
             
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 dest[offset] = AntennaNoisedB;
             }
@@ -592,7 +592,7 @@ namespace PacketDotNet
             /// <param name='AntennaNoisedB'>
             /// Antenna signal noise in dB.
             /// </param>
-            public DbAntennaNoiseRadioTapField(byte AntennaNoisedB)
+            public DbAntennaNoiseRadioTapField(Byte AntennaNoisedB)
             {
                 this.AntennaNoisedB = AntennaNoisedB;
             }
@@ -603,9 +603,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("AntennaNoisedB {0}", AntennaNoisedB);
+                return String.Format("AntennaNoisedB {0}", AntennaNoisedB);
             }
         }
 
@@ -623,17 +623,17 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 1; } }
+            public override UInt16 Length { get { return 1; } }
             
             /// <summary>
             /// Antenna number
             /// </summary>
-            public byte Antenna { get; set; }
+            public Byte Antenna { get; set; }
             
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 dest[offset] = Antenna;
             }
@@ -663,7 +663,7 @@ namespace PacketDotNet
             /// <param name='Antenna'>
             /// Antenna index of the Rx/Tx antenna for this packet. The first antenna is antenna 0.
             /// </param>
-            public AntennaRadioTapField (byte Antenna)
+            public AntennaRadioTapField (Byte Antenna)
             {
                 this.Antenna = Antenna;
             }
@@ -674,9 +674,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("Antenna {0}", Antenna);
+                return String.Format("Antenna {0}", Antenna);
             }
         }
 
@@ -694,19 +694,19 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 1; } }
+            public override UInt16 Length { get { return 1; } }
             
             /// <summary>
             /// Antenna signal in dBm
             /// </summary>
-            public sbyte AntennaSignalDbm { get; set; }
+            public SByte AntennaSignalDbm { get; set; }
             
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
-                dest[offset] = (byte)AntennaSignalDbm;
+                dest[offset] = (Byte)AntennaSignalDbm;
             }
 
             /// <summary>
@@ -734,7 +734,7 @@ namespace PacketDotNet
             /// <param name='AntennaSignalDbm'>
             /// Antenna signal power in dB.
             /// </param>
-            public DbmAntennaSignalRadioTapField (sbyte AntennaSignalDbm)
+            public DbmAntennaSignalRadioTapField (SByte AntennaSignalDbm)
             {
                 this.AntennaSignalDbm = AntennaSignalDbm;
             }
@@ -745,9 +745,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("AntennaSignalDbm {0}", AntennaSignalDbm);
+                return String.Format("AntennaSignalDbm {0}", AntennaSignalDbm);
             }
         }
 
@@ -765,19 +765,19 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 1; } }
+            public override UInt16 Length { get { return 1; } }
             
             /// <summary>
             /// Antenna noise in dBm
             /// </summary>
-            public sbyte AntennaNoisedBm { get; set; }
+            public SByte AntennaNoisedBm { get; set; }
             
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
-                dest[offset] = (byte)AntennaNoisedBm;
+                dest[offset] = (Byte)AntennaNoisedBm;
             }
 
             /// <summary>
@@ -805,7 +805,7 @@ namespace PacketDotNet
             /// <param name='AntennaNoisedBm'>
             /// Antenna noise in dBm.
             /// </param>
-            public DbmAntennaNoiseRadioTapField (sbyte AntennaNoisedBm)
+            public DbmAntennaNoiseRadioTapField (SByte AntennaNoisedBm)
             {
                 this.AntennaNoisedBm = AntennaNoisedBm;
             }
@@ -816,9 +816,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("AntennaNoisedBm {0}", AntennaNoisedBm);
+                return String.Format("AntennaNoisedBm {0}", AntennaNoisedBm);
             }
         }
 
@@ -837,7 +837,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 2; } }
+            public override UInt16 Length { get { return 2; } }
             
             /// <summary>
             /// Signal quality
@@ -847,7 +847,7 @@ namespace PacketDotNet
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 EndianBitConverter.Little.CopyBytes(SignalQuality, dest, offset);
             }
@@ -888,9 +888,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("SignalQuality {0}", SignalQuality);
+                return String.Format("SignalQuality {0}", SignalQuality);
             }
         }
 
@@ -908,7 +908,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 8; } }
+            public override UInt16 Length { get { return 8; } }
             
             /// <summary>
             /// Timestamp in microseconds
@@ -918,7 +918,7 @@ namespace PacketDotNet
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 EndianBitConverter.Little.CopyBytes(TimestampUsec, dest, offset);
             }
@@ -959,9 +959,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("TimestampUsec {0}", TimestampUsec);
+                return String.Format("TimestampUsec {0}", TimestampUsec);
             }
         }
 
@@ -979,7 +979,7 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 2; } }
+            public override UInt16 Length { get { return 2; } }
             
             /// <summary>
             /// Gets or sets a value indicating whether the frame failed the PLCP CRC check.
@@ -987,12 +987,12 @@ namespace PacketDotNet
             /// <value>
             /// <c>true</c> if the PLCP CRC check failed; otherwise, <c>false</c>.
             /// </value>
-            public bool PlcpCrcCheckFailed {get; set;}
+            public Boolean PlcpCrcCheckFailed {get; set;}
             
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 UInt16 flags = (UInt16)((PlcpCrcCheckFailed) ? 0x2 : 0x0);
                 EndianBitConverter.Little.CopyBytes(flags, dest, offset);
@@ -1024,7 +1024,7 @@ namespace PacketDotNet
             /// <param name='PlcpCrcCheckFailed'>
             /// PLCP CRC check failed.
             /// </param>
-            public RxFlagsRadioTapField(bool PlcpCrcCheckFailed)
+            public RxFlagsRadioTapField(Boolean PlcpCrcCheckFailed)
             {
                 this.PlcpCrcCheckFailed = PlcpCrcCheckFailed;
             }
@@ -1035,9 +1035,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("PlcpCrcCheckFailed {0}", PlcpCrcCheckFailed);
+                return String.Format("PlcpCrcCheckFailed {0}", PlcpCrcCheckFailed);
             }
         }
         
@@ -1058,17 +1058,17 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 2; } }
+            public override UInt16 Length { get { return 2; } }
             
             /// <summary>
             /// Transmit power
             /// </summary>
-            public int TxPower { get; set; }
+            public Int32 TxPower { get; set; }
    
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 UInt16 absValue = (UInt16) Math.Abs(TxPower);
                 EndianBitConverter.Little.CopyBytes(absValue, dest, offset);
@@ -1082,7 +1082,7 @@ namespace PacketDotNet
             /// </param>
             public TxAttenuationRadioTapField(BinaryReader br)
             {
-                TxPower = -(int)br.ReadUInt16();
+                TxPower = -(Int32)br.ReadUInt16();
             }
             
             /// <summary>
@@ -1099,7 +1099,7 @@ namespace PacketDotNet
             /// <param name='TxPower'>
             /// Transmit power expressed as unitless distance from max power set at factory calibration. 0 is max power.
             /// </param>
-            public TxAttenuationRadioTapField (int TxPower)
+            public TxAttenuationRadioTapField (Int32 TxPower)
             {
                 this.TxPower = TxPower;
             }
@@ -1110,9 +1110,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("TxPower {0}", TxPower);
+                return String.Format("TxPower {0}", TxPower);
             }
         }
 
@@ -1132,17 +1132,17 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 2; } }
+            public override UInt16 Length { get { return 2; } }
             
             /// <summary>
             /// Transmit power 
             /// </summary>
-            public int TxPowerdB { get; set; }
+            public Int32 TxPowerdB { get; set; }
    
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
                 UInt16 absValue = (UInt16) Math.Abs(TxPowerdB);
                 EndianBitConverter.Little.CopyBytes(absValue, dest, offset);
@@ -1156,7 +1156,7 @@ namespace PacketDotNet
             /// </param>
             public DbTxAttenuationRadioTapField(BinaryReader br)
             {
-                TxPowerdB = -(int)br.ReadUInt16();
+                TxPowerdB = -(Int32)br.ReadUInt16();
             }
             
             /// <summary>
@@ -1173,7 +1173,7 @@ namespace PacketDotNet
             /// <param name='TxPowerdB'>
             /// Transmit power expressed as decibel distance from max power set at factory calibration. 0 is max power.
             /// </param>
-            public DbTxAttenuationRadioTapField(int TxPowerdB)
+            public DbTxAttenuationRadioTapField(Int32 TxPowerdB)
             {
                 this.TxPowerdB = TxPowerdB;
             }
@@ -1184,9 +1184,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("TxPowerdB {0}", TxPowerdB);
+                return String.Format("TxPowerdB {0}", TxPowerdB);
             }
         }
 
@@ -1206,19 +1206,19 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public override ushort Length { get { return 1; } }
+            public override UInt16 Length { get { return 1; } }
             
             /// <summary>
             /// Tx power in dBm
             /// </summary>
-            public sbyte TxPowerdBm { get; set; }
+            public SByte TxPowerdBm { get; set; }
    
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public override void CopyTo(byte[] dest, int offset)
+            public override void CopyTo(Byte[] dest, Int32 offset)
             {
-                dest[offset] = (byte)TxPowerdBm;
+                dest[offset] = (Byte)TxPowerdBm;
             }
             
             /// <summary>
@@ -1246,7 +1246,7 @@ namespace PacketDotNet
             /// <param name='TxPowerdBm'>
             /// Transmit power expressed as dBm (decibels from a 1 milliwatt reference).
             /// </param>
-            public DbmTxPowerRadioTapField(sbyte TxPowerdBm)
+            public DbmTxPowerRadioTapField(SByte TxPowerdBm)
             {
                 this.TxPowerdBm = TxPowerdBm;
             }
@@ -1257,9 +1257,9 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="System.String"/>
             /// </returns>
-            public override string ToString()
+            public override String ToString()
             {
-                return string.Format("TxPowerdBm {0}", TxPowerdBm);
+                return String.Format("TxPowerdBm {0}", TxPowerdBm);
             }
         }
 
@@ -1284,7 +1284,7 @@ namespace PacketDotNet
             /// <returns>
             /// A <see cref="RadioTapField"/>
             /// </returns>
-            public static RadioTapField Parse(int bitIndex, BinaryReader br)
+            public static RadioTapField Parse(Int32 bitIndex, BinaryReader br)
             {
                 var Type = (RadioTapType)bitIndex;
                 switch (Type)
@@ -1331,12 +1331,12 @@ namespace PacketDotNet
             /// <value>
             /// The length.
             /// </value>
-            public abstract ushort Length {get;}
+            public abstract UInt16 Length {get;}
             
             /// <summary>
             /// Copies the field data to the destination buffer at the specified offset.
             /// </summary>
-            public abstract void CopyTo(byte[] dest, int offset);
+            public abstract void CopyTo(Byte[] dest, Int32 offset);
         }; 
     }
 }

--- a/PacketDotNet/Ieee80211/ReassociationRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/ReassociationRequestFrame.cs
@@ -40,13 +40,13 @@ namespace PacketDotNet
         {
             private class ReassociationRequestFields
             {
-                public readonly static int CapabilityInformationLength = 2;
-                public readonly static int ListenIntervalLength = 2;
+                public readonly static Int32 CapabilityInformationLength = 2;
+                public readonly static Int32 ListenIntervalLength = 2;
 
-                public readonly static int CapabilityInformationPosition;
-                public readonly static int ListenIntervalPosition;
-                public readonly static int CurrentAccessPointPosition;
-                public readonly static int InformationElement1Position;
+                public readonly static Int32 CapabilityInformationPosition;
+                public readonly static Int32 ListenIntervalPosition;
+                public readonly static Int32 CurrentAccessPointPosition;
+                public readonly static Int32 InformationElement1Position;
 
                 static ReassociationRequestFields()
                 {
@@ -163,7 +163,7 @@ namespace PacketDotNet
             /// <value>
             /// The size of the frame.
             /// </value>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/RtsFrame.cs
+++ b/PacketDotNet/Ieee80211/RtsFrame.cs
@@ -48,7 +48,7 @@ namespace PacketDotNet
             /// <summary>
             /// Length of the frame
             /// </summary>
-            public override int FrameSize
+            public override Int32 FrameSize
             {
                 get
                 {

--- a/PacketDotNet/Ieee80211/SequenceControlField.cs
+++ b/PacketDotNet/Ieee80211/SequenceControlField.cs
@@ -46,11 +46,11 @@ namespace PacketDotNet
             /// <value>
             /// The sequence number.
             /// </value>
-            public short SequenceNumber
+            public Int16 SequenceNumber
             {
                 get
                 {
-                    return (short)(Field >> 4);
+                    return (Int16)(Field >> 4);
                 }
 
                 set
@@ -67,16 +67,16 @@ namespace PacketDotNet
             /// <value>
             /// The fragment number.
             /// </value>
-            public byte FragmentNumber
+            public Byte FragmentNumber
             {
                 get
                 {
-                    return (byte)(Field & 0x000F);
+                    return (Byte)(Field & 0x000F);
                 }
 
                 set
                 {
-                    Field &= unchecked((ushort)~0xF);
+                    Field &= unchecked((UInt16)~0xF);
                     Field |= (UInt16)(value & 0x0F);
                 }
             }

--- a/PacketDotNet/Ieee8021QFields.cs
+++ b/PacketDotNet/Ieee8021QFields.cs
@@ -17,21 +17,24 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2013 Chris Morgan <chmorgan@gmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary> 802.1Q fields </summary>
     public class Ieee8021QFields
     {
         /// <summary> Length of the ethertype value in bytes.</summary>
-        public readonly static int TypeLength = 2;
+        public readonly static Int32 TypeLength = 2;
         /// <summary> Length of the tag control information in bytes. </summary>
-        public readonly static int TagControlInformationLength = 2;
+        public readonly static Int32 TagControlInformationLength = 2;
         /// <summary> Position of the tag control information </summary>
-        public readonly static int TagControlInformationPosition = 0;
+        public readonly static Int32 TagControlInformationPosition = 0;
         /// <summary> Position of the type field </summary>
-        public readonly static int TypePosition;
+        public readonly static Int32 TypePosition;
         /// <summary> Length in bytes of a Ieee8021Q header.</summary>
-        public readonly static int HeaderLength; // 4
+        public readonly static Int32 HeaderLength; // 4
 
         static Ieee8021QFields()
         {

--- a/PacketDotNet/Ieee8021QPacket.cs
+++ b/PacketDotNet/Ieee8021QPacket.cs
@@ -72,8 +72,8 @@ namespace PacketDotNet
                 var tci = TagControlInformation;
 
                 // mask the existing Priority off and then back in from value
-                ushort val = (ushort)value;
-                tci = (ushort)((tci & 0x1FFF) | ((val & 0x7) << (16 - 3)));
+                UInt16 val = (UInt16)value;
+                tci = (UInt16)((tci & 0x1FFF) | ((val & 0x7) << (16 - 3)));
                 TagControlInformation = tci;
             }
         }
@@ -84,7 +84,7 @@ namespace PacketDotNet
         /// <value>
         /// <c>true</c> if the mac address is in non-canonical format <c>false</c> if otherwise.
         /// </value>
-        public bool CanonicalFormatIndicator
+        public Boolean CanonicalFormatIndicator
         {
             get
             {
@@ -98,8 +98,8 @@ namespace PacketDotNet
                 var tci = TagControlInformation;
 
                 // mask the existing CFI off and then back in from value
-                int val = ((value == true) ? 1 : 0);
-                tci = (ushort)((tci & 0xEFFF) | (val << 12));
+                Int32 val = ((value == true) ? 1 : 0);
+                tci = (UInt16)((tci & 0xEFFF) | (val << 12));
                 TagControlInformation = tci;
             }
         }
@@ -110,12 +110,12 @@ namespace PacketDotNet
         /// <value>
         /// The VLAN identifier.
         /// </value>
-        public ushort VLANIdentifier
+        public UInt16 VLANIdentifier
         {
             get
             {
                 var tci = TagControlInformation;
-                return (ushort)(tci & 0xFFF);
+                return (UInt16)(tci & 0xFFF);
             }
 
             set
@@ -123,16 +123,16 @@ namespace PacketDotNet
                 var tci = TagControlInformation;
 
                 // mask the existing vlan id off
-                tci = (ushort)((tci & 0xF000) | (value & 0xFFF));
+                tci = (UInt16)((tci & 0xF000) | (value & 0xFFF));
                 TagControlInformation = tci;
             }
         }
 
-        private ushort TagControlInformation
+        private UInt16 TagControlInformation
         {
             get
             {
-                return (ushort)EndianBitConverter.Big.ToInt16(header.Bytes,
+                return (UInt16)EndianBitConverter.Big.ToInt16(header.Bytes,
                                                               header.Offset + Ieee8021QFields.TagControlInformationPosition);
             }
 
@@ -172,11 +172,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -198,14 +198,14 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("priority", PriorityControlPoint + " (0x" + PriorityControlPoint.ToString("x") + ")");
                 properties.Add("canonical format indicator", CanonicalFormatIndicator.ToString());
                 properties.Add("type", Type.ToString() + " (0x" + Type.ToString("x") + ")");
                 properties.Add ("VLANIdentifier", VLANIdentifier.ToString () + " (0x" + VLANIdentifier.ToString ("x") + ")");
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("Ieee802.1Q:  ******* Ieee802.1Q - \"VLan tag\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/IpPacket.cs
+++ b/PacketDotNet/IpPacket.cs
@@ -45,7 +45,7 @@ namespace PacketDotNet
         /// <summary>
         /// The default time to live value for Ip packets being constructed
         /// </summary>
-        protected int DefaultTimeToLive = 64;
+        protected Int32 DefaultTimeToLive = 64;
 
         /// <value>
         /// Payload packet, overridden to set the NextHeader/Protocol based
@@ -88,7 +88,7 @@ namespace PacketDotNet
 
                 // update the payload length based on the size
                 // of the payload packet
-                var newPayloadLength = (ushort)base.PayloadPacket.Bytes.Length;
+                var newPayloadLength = (UInt16)base.PayloadPacket.Bytes.Length;
                 log.DebugFormat("newPayloadLength {0}", newPayloadLength);
                 PayloadLength = newPayloadLength;
             }
@@ -147,7 +147,7 @@ namespace PacketDotNet
         /// Named 'TimeToLive' in IPv4
         /// Named 'HopLimit' in IPv6
         /// </value>
-        public abstract int TimeToLive
+        public abstract Int32 TimeToLive
         {
             get;
             set;
@@ -157,7 +157,7 @@ namespace PacketDotNet
         /// The number of hops remaining for this packet
         /// Included along side of TimeToLive for user convienence
         /// </value>
-        public virtual int HopLimit
+        public virtual Int32 HopLimit
         {
             get { return TimeToLive; }
             set { TimeToLive = value; }
@@ -168,7 +168,7 @@ namespace PacketDotNet
         /// NOTE: This field is the number of 32bit words in the ip header,
         ///       ie. the number of bytes is 4x this value
         /// </summary>
-        public abstract int HeaderLength
+        public abstract Int32 HeaderLength
         {
             get; set;
         }
@@ -177,7 +177,7 @@ namespace PacketDotNet
         /// ipv4 total number of bytes in the ipv4 header + payload,
         /// ipv6 PayloadLength + IPv6Fields.HeaderLength
         /// </summary>
-        public abstract int TotalLength
+        public abstract Int32 TotalLength
         {
             get; set;
         }
@@ -186,7 +186,7 @@ namespace PacketDotNet
         /// ipv6 payload length in bytes,
         /// calculate from ipv4.TotalLength - (ipv4.HeaderLength * 4)
         /// </summary>
-        public abstract ushort PayloadLength
+        public abstract UInt16 PayloadLength
         {
             get;
             set;
@@ -202,7 +202,7 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.Byte"/>
         /// </returns>
-        internal abstract byte[] AttachPseudoIPHeader(byte[] origHeader);
+        internal abstract Byte[] AttachPseudoIPHeader(Byte[] origHeader);
 
         /// <summary>
         /// Convert an ip address from a byte[]
@@ -220,16 +220,16 @@ namespace PacketDotNet
         /// A <see cref="System.Net.IPAddress"/>
         /// </returns>
         public static System.Net.IPAddress GetIPAddress(System.Net.Sockets.AddressFamily ipType,
-                                                        int fieldOffset,
-                                                        byte[] bytes)
+                                                        Int32 fieldOffset,
+                                                        Byte[] bytes)
         {
-            byte[] address;
+            Byte[] address;
             if(ipType == System.Net.Sockets.AddressFamily.InterNetwork) // ipv4
             {
-                address = new byte[IPv4Fields.AddressLength];
+                address = new Byte[IPv4Fields.AddressLength];
             } else if(ipType == System.Net.Sockets.AddressFamily.InterNetworkV6)
             {
-                address = new byte[IPv6Fields.AddressLength];
+                address = new Byte[IPv6Fields.AddressLength];
             } else
             {
                 throw new System.InvalidOperationException("ipType " + ipType + " unknown");

--- a/PacketDotNet/L2TPFields.cs
+++ b/PacketDotNet/L2TPFields.cs
@@ -17,6 +17,9 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2018 Steven Haufe<haufes@hotmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary> L2TP protocol field encoding information. </summary>
@@ -24,19 +27,19 @@ namespace PacketDotNet
     {
 
         /// <summary> Length of the Base Header in bytes.</summary>
-        public readonly static int HeaderLength = 2;
+        public readonly static Int32 HeaderLength = 2;
         /// <summary> Length of the Flags in bytes.</summary>
-        public readonly static int FlagsLength = 2;
+        public readonly static Int32 FlagsLength = 2;
         /// <summary> Length of the Length in bytes.</summary>
-        public readonly static int LengthsLength = 2;
+        public readonly static Int32 LengthsLength = 2;
         /// <summary> Length of the Ns in bytes.</summary>
-        public readonly static int NsLength = 2;
+        public readonly static Int32 NsLength = 2;
         /// <summary> Length of the Nr in bytes.</summary>
-        public readonly static int NrLength = 2;
+        public readonly static Int32 NrLength = 2;
         /// <summary> Length of the Offset Size in bytes (Optional).</summary>      
-        public readonly static int OffsetSizeLength = 2;
+        public readonly static Int32 OffsetSizeLength = 2;
         /// <summary> Length of the Offset Pad in bytes (Optional).</summary>
-        public readonly static int OffsetPadLength = 2;
+        public readonly static Int32 OffsetPadLength = 2;
 
 
     }

--- a/PacketDotNet/L2TPPacket.cs
+++ b/PacketDotNet/L2TPPacket.cs
@@ -32,14 +32,14 @@ namespace PacketDotNet
     public class L2TPPacket : Packet
     {
 
-        virtual public bool DataMessage
+        virtual public Boolean DataMessage
         {
             get
             {
                 return 8 == (header.Bytes[header.Offset] & 0x8);
             }
         }
-        virtual public bool HasLength
+        virtual public Boolean HasLength
         {
             get
             {
@@ -47,7 +47,7 @@ namespace PacketDotNet
             }
         }
 
-        virtual public bool HasSequence
+        virtual public Boolean HasSequence
         {
             get
             {
@@ -55,7 +55,7 @@ namespace PacketDotNet
             }
         }
 
-        virtual public bool HasOffset
+        virtual public Boolean HasOffset
         {
             get
             {
@@ -63,7 +63,7 @@ namespace PacketDotNet
             }
         }
 
-        virtual public bool IsPriority
+        virtual public Boolean IsPriority
         {
             get
             {
@@ -71,7 +71,7 @@ namespace PacketDotNet
             }
         }
 
-        virtual public int Version
+        virtual public Int32 Version
         {
             get
             {
@@ -79,7 +79,7 @@ namespace PacketDotNet
             }
         }
 
-        virtual public int TunnelID
+        virtual public Int32 TunnelID
         {
             get
             {
@@ -91,7 +91,7 @@ namespace PacketDotNet
             }
         }
 
-        virtual public int SessionID
+        virtual public Int32 SessionID
         {
             get
             {
@@ -147,11 +147,11 @@ namespace PacketDotNet
 
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
             
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)

--- a/PacketDotNet/LLDP/ChassisID.cs
+++ b/PacketDotNet/LLDP/ChassisID.cs
@@ -44,7 +44,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Length of the sub type field in bytes
         /// </summary>
-        private const int SubTypeLength = 1;
+        private const Int32 SubTypeLength = 1;
 
         #region Constructors
 
@@ -57,7 +57,7 @@ namespace PacketDotNet.LLDP
         /// The Chassis ID TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public ChassisID(byte[] bytes, int offset) :
+        public ChassisID(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {
             log.Debug("");
@@ -72,7 +72,7 @@ namespace PacketDotNet.LLDP
         /// <param name="subTypeValue">
         /// The subtype's value
         /// </param>
-        public ChassisID(ChassisSubTypes subType, object subTypeValue)
+        public ChassisID(ChassisSubTypes subType, Object subTypeValue)
         {
             log.DebugFormat("subType {0}", subType);
 
@@ -111,7 +111,7 @@ namespace PacketDotNet.LLDP
         /// <param name="InterfaceName">
         /// A <see cref="System.String"/>
         /// </param>
-        public ChassisID(string InterfaceName)
+        public ChassisID(String InterfaceName)
         {
             log.DebugFormat("InterfaceName {0}", InterfaceName);
 
@@ -140,14 +140,14 @@ namespace PacketDotNet.LLDP
             set
             {
                 // set the subtype
-                tlvData.Bytes[ValueOffset] = (byte)value;
+                tlvData.Bytes[ValueOffset] = (Byte)value;
             }
         }
 
         /// <value>
         /// The TLV subtype value
         /// </value>
-        public object SubTypeValue
+        public Object SubTypeValue
         {
             get { return GetSubTypeValue(); }
             set { SetSubTypeValue(value); }
@@ -156,9 +156,9 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// If SubType is ChassisComponent
         /// </summary>
-        public byte[] ChassisComponent
+        public Byte[] ChassisComponent
         {
-            get { return (byte[])GetSubTypeValue(); }
+            get { return (Byte[])GetSubTypeValue(); }
             set
             {
                 SubType = ChassisSubTypes.ChassisComponent;
@@ -169,9 +169,9 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// If SubType is InterfaceName the interface name
         /// </summary>
-        public string InterfaceName
+        public String InterfaceName
         {
-            get { return (string)GetSubTypeValue(); }
+            get { return (String)GetSubTypeValue(); }
             set
             {
                 SubType = ChassisSubTypes.InterfaceName;
@@ -208,9 +208,9 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// If SubType is PortComponent
         /// </summary>
-        public byte[] PortComponent
+        public Byte[] PortComponent
         {
-            get { return (byte[])GetSubTypeValue(); }
+            get { return (Byte[])GetSubTypeValue(); }
             set
             {
                 SubType = ChassisSubTypes.PortComponent;
@@ -221,9 +221,9 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// If SubType is InterfaceAlias
         /// </summary>
-        public byte[] InterfaceAlias
+        public Byte[] InterfaceAlias
         {
-            get { return (byte[])GetSubTypeValue(); }
+            get { return (Byte[])GetSubTypeValue(); }
             set
             {
                 SubType = ChassisSubTypes.InterfaceAlias;
@@ -241,16 +241,16 @@ namespace PacketDotNet.LLDP
         private void EmptyTLVDataInit()
         {
             var length = TLVTypeLength.TypeLengthLength + SubTypeLength;
-            var bytes = new byte[length];
-            int offset = 0;
+            var bytes = new Byte[length];
+            Int32 offset = 0;
             tlvData = new ByteArraySegment(bytes, offset, length);
         }
 
-        private object GetSubTypeValue()
+        private Object GetSubTypeValue()
         {
-            byte[] val;
-            int dataOffset = ValueOffset + SubTypeLength;
-            int dataLength = Length - SubTypeLength;
+            Byte[] val;
+            Int32 dataOffset = ValueOffset + SubTypeLength;
+            Int32 dataLength = Length - SubTypeLength;
 
             switch (SubType)
             {
@@ -258,7 +258,7 @@ namespace PacketDotNet.LLDP
                 case ChassisSubTypes.InterfaceAlias:
                 case ChassisSubTypes.LocallyAssigned:
                 case ChassisSubTypes.PortComponent:
-                    val = new byte[dataLength];
+                    val = new Byte[dataLength];
                     Array.Copy(tlvData.Bytes, dataOffset,
                                val, 0,
                                dataLength);
@@ -268,7 +268,7 @@ namespace PacketDotNet.LLDP
                                               dataOffset,
                                               dataLength);
                 case ChassisSubTypes.MACAddress:
-                    val = new byte[dataLength];
+                    val = new Byte[dataLength];
                     Array.Copy(tlvData.Bytes, dataOffset,
                                val, 0,
                                dataLength);
@@ -280,9 +280,9 @@ namespace PacketDotNet.LLDP
             }
         }
 
-        private void SetSubTypeValue(object val)
+        private void SetSubTypeValue(Object val)
         {
-            byte[] valBytes;
+            Byte[] valBytes;
 
             // make sure we have the correct type
             switch (SubType)
@@ -291,12 +291,12 @@ namespace PacketDotNet.LLDP
                 case ChassisSubTypes.InterfaceAlias:
                 case ChassisSubTypes.LocallyAssigned:
                 case ChassisSubTypes.PortComponent:
-                    if(!(val is byte[]))
+                    if(!(val is Byte[]))
                     {
                         throw new ArgumentOutOfRangeException("expected byte[] for type");
                     }
 
-                    valBytes = (byte[])val;
+                    valBytes = (Byte[])val;
 
                     SetSubTypeValue(valBytes);
                     break;
@@ -311,12 +311,12 @@ namespace PacketDotNet.LLDP
                     SetSubTypeValue(valBytes);
                     break;
                 case ChassisSubTypes.InterfaceName:
-                    if(!(val is string))
+                    if(!(val is String))
                     {
                         throw new ArgumentOutOfRangeException("expected string for InterfaceName");
                     }
 
-                    var interfaceName = (string)val;
+                    var interfaceName = (String)val;
 
                     valBytes = System.Text.ASCIIEncoding.ASCII.GetBytes(interfaceName);
 
@@ -337,13 +337,13 @@ namespace PacketDotNet.LLDP
             }
         }
 
-        private void SetSubTypeValue(byte[] subTypeValue)
+        private void SetSubTypeValue(Byte[] subTypeValue)
         {
             // is the length different than the current length?
             if(subTypeValue.Length != Length)
             {
                 var headerLength = TLVTypeLength.TypeLengthLength + SubTypeLength;
-                var newTlvMemory = new byte[headerLength + subTypeValue.Length];
+                var newTlvMemory = new Byte[headerLength + subTypeValue.Length];
 
                 // copy the header data over
                 Array.Copy(tlvData.Bytes, tlvData.Offset, newTlvMemory, 0, headerLength);
@@ -362,9 +362,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A human readable string
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[ChassisID: SubType={0}, SubTypeValue={1}]", SubType, SubTypeValue);
+            return String.Format("[ChassisID: SubType={0}, SubTypeValue={1}]", SubType, SubTypeValue);
         }
 
         #endregion

--- a/PacketDotNet/LLDP/EndOfLLDPDU.cs
+++ b/PacketDotNet/LLDP/EndOfLLDPDU.cs
@@ -39,7 +39,7 @@ namespace PacketDotNet.LLDP
         /// The End Of LLDPDU TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public EndOfLLDPDU(byte[] bytes, int offset) :
+        public EndOfLLDPDU(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {
             Type = 0;
@@ -51,7 +51,7 @@ namespace PacketDotNet.LLDP
         /// </summary>
         public EndOfLLDPDU()
         {
-            var bytes = new byte[TLVTypeLength.TypeLengthLength];
+            var bytes = new Byte[TLVTypeLength.TypeLengthLength];
             var offset = 0;
             var length = bytes.Length;
             tlvData = new PacketDotNet.Utils.ByteArraySegment(bytes, offset, length);
@@ -66,9 +66,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A human readable string
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[EndOfLLDPDU]");
+            return String.Format("[EndOfLLDPDU]");
         }
 
         #endregion

--- a/PacketDotNet/LLDP/ManagementAddress.cs
+++ b/PacketDotNet/LLDP/ManagementAddress.cs
@@ -48,27 +48,27 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Number of bytes in the AddressLength field
         /// </summary>
-        private const int MgmtAddressLengthLength = 1;
+        private const Int32 MgmtAddressLengthLength = 1;
 
         /// <summary>
         /// Number of bytes in the interface number subtype field
         /// </summary>
-        private const int InterfaceNumberSubTypeLength = 1;
+        private const Int32 InterfaceNumberSubTypeLength = 1;
 
         /// <summary>
         /// Number of bytes in the interface number field
         /// </summary>
-        private const int InterfaceNumberLength = 4;
+        private const Int32 InterfaceNumberLength = 4;
 
         /// <summary>
         /// Number of bytes in the object identifier length field
         /// </summary>
-        private const int ObjectIdentifierLengthLength = 1;
+        private const Int32 ObjectIdentifierLengthLength = 1;
 
         /// <summary>
         /// Maximum number of bytes in the object identifier field
         /// </summary>
-        private const int maxObjectIdentifierLength = 128;
+        private const Int32 maxObjectIdentifierLength = 128;
 
         #region Constructors
 
@@ -82,7 +82,7 @@ namespace PacketDotNet.LLDP
         /// The Management Address TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public ManagementAddress(byte[] bytes, int offset) :
+        public ManagementAddress(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {
             log.Debug("");
@@ -104,8 +104,8 @@ namespace PacketDotNet.LLDP
         /// The Object Identifier
         /// </param>
         public ManagementAddress(NetworkAddress managementAddress,
-                                 InterfaceNumbering interfaceSubType, uint ifNumber,
-                                 string oid)
+                                 InterfaceNumbering interfaceSubType, UInt32 ifNumber,
+                                 String oid)
         {
             log.Debug("");
 
@@ -114,7 +114,7 @@ namespace PacketDotNet.LLDP
             var length = TLVTypeLength.TypeLengthLength + MgmtAddressLengthLength +
                          InterfaceNumberSubTypeLength + InterfaceNumberLength +
                          ObjectIdentifierLengthLength;
-            var bytes = new byte[length];
+            var bytes = new Byte[length];
             var offset = 0;
             tlvData = new ByteArraySegment(bytes, offset, length);
 
@@ -137,10 +137,10 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// The Management Address Length
         /// </value>
-        public int AddressLength
+        public Int32 AddressLength
         {
-            get { return (int)tlvData.Bytes[ValueOffset]; }
-            internal set { tlvData.Bytes[ValueOffset] = (byte)value; }
+            get { return (Int32)tlvData.Bytes[ValueOffset]; }
+            internal set { tlvData.Bytes[ValueOffset] = (Byte)value; }
         }
 
         /// <value>
@@ -160,7 +160,7 @@ namespace PacketDotNet.LLDP
         {
             get
             {
-                int offset = ValueOffset + MgmtAddressLengthLength;
+                Int32 offset = ValueOffset + MgmtAddressLengthLength;
 
                 return new NetworkAddress(tlvData.Bytes, offset, AddressLength);
             }
@@ -181,12 +181,12 @@ namespace PacketDotNet.LLDP
                                     ObjectIdentifierLengthLength +
                                     ObjIdLength;
 
-                    var newBytes = new byte[newLength];
+                    var newBytes = new Byte[newLength];
 
-                    int headerLength = TLVTypeLength.TypeLengthLength + MgmtAddressLengthLength;
-                    int oldStartOfAfterData = ValueOffset + MgmtAddressLengthLength + AddressLength;
-                    int newStartOfAfterData = TLVTypeLength.TypeLengthLength + MgmtAddressLengthLength + value.Length;
-                    int afterDataLength = InterfaceNumberSubTypeLength + InterfaceNumberLength + ObjectIdentifierLengthLength + ObjIdLength;
+                    Int32 headerLength = TLVTypeLength.TypeLengthLength + MgmtAddressLengthLength;
+                    Int32 oldStartOfAfterData = ValueOffset + MgmtAddressLengthLength + AddressLength;
+                    Int32 newStartOfAfterData = TLVTypeLength.TypeLengthLength + MgmtAddressLengthLength + value.Length;
+                    Int32 afterDataLength = InterfaceNumberSubTypeLength + InterfaceNumberLength + ObjectIdentifierLengthLength + ObjIdLength;
 
                     // copy the data before the mgmt address
                     Array.Copy(tlvData.Bytes, tlvData.Offset,
@@ -224,11 +224,11 @@ namespace PacketDotNet.LLDP
 
             set
             {
-                tlvData.Bytes[ValueOffset + MgmtAddressLengthLength + MgmtAddress.Length] = (byte)value;
+                tlvData.Bytes[ValueOffset + MgmtAddressLengthLength + MgmtAddress.Length] = (Byte)value;
             }
         }
 
-        private int InterfaceNumberOffset
+        private Int32 InterfaceNumberOffset
         {
             get
             {
@@ -239,7 +239,7 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// Interface Number
         /// </value>
-        public uint InterfaceNumber
+        public UInt32 InterfaceNumber
         {
             get
             {
@@ -255,7 +255,7 @@ namespace PacketDotNet.LLDP
             }
         }
 
-        private int ObjIdLengthOffset
+        private Int32 ObjIdLengthOffset
         {
             get
             {
@@ -266,7 +266,7 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// Object ID Length
         /// </value>
-        public byte ObjIdLength
+        public Byte ObjIdLength
         {
             get
             {
@@ -279,7 +279,7 @@ namespace PacketDotNet.LLDP
             }
         }
 
-        private int ObjectIdentifierOffset
+        private Int32 ObjectIdentifierOffset
         {
             get { return ObjIdLengthOffset + ObjectIdentifierLengthLength; }
         }
@@ -287,7 +287,7 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// Object ID
         /// </value>
-        public string ObjectIdentifier
+        public String ObjectIdentifier
         {
             get
             {
@@ -297,7 +297,7 @@ namespace PacketDotNet.LLDP
 
             set
             {
-                byte[] oid = UTF8Encoding.UTF8.GetBytes(value);
+                Byte[] oid = UTF8Encoding.UTF8.GetBytes(value);
 
                 // check for out-of-range sizes
                 if(oid.Length > maxObjectIdentifierLength)
@@ -314,7 +314,7 @@ namespace PacketDotNet.LLDP
                                     ObjectIdentifierLengthLength;
                     var newLength = oldLength + oid.Length;
 
-                    var newBytes = new byte[newLength];
+                    var newBytes = new Byte[newLength];
 
                     // copy the original bytes over
                     Array.Copy(tlvData.Bytes, tlvData.Offset,
@@ -325,7 +325,7 @@ namespace PacketDotNet.LLDP
                     tlvData = new ByteArraySegment(newBytes, offset, newLength);
 
                     // update the length
-                    ObjIdLength = (byte)value.Length;
+                    ObjIdLength = (Byte)value.Length;
                 }
 
                 Array.Copy(oid, 0,
@@ -340,9 +340,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A human readable string
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[ManagementAddress: AddressLength={0}, AddressSubType={1}, MgmtAddress={2}, InterfaceSubType={3}, InterfaceNumber={4}, ObjIdLength={5}, ObjectIdentifier={6}]", AddressLength, AddressSubType, MgmtAddress, InterfaceSubType, InterfaceNumber, ObjIdLength, ObjectIdentifier);
+            return String.Format("[ManagementAddress: AddressLength={0}, AddressSubType={1}, MgmtAddress={2}, InterfaceSubType={3}, InterfaceNumber={4}, ObjIdLength={5}, ObjectIdentifier={6}]", AddressLength, AddressSubType, MgmtAddress, InterfaceSubType, InterfaceNumber, ObjIdLength, ObjectIdentifier);
         }
 
         #endregion

--- a/PacketDotNet/LLDP/NetworkAddress.cs
+++ b/PacketDotNet/LLDP/NetworkAddress.cs
@@ -31,7 +31,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Length of AddressFamily field in bytes
         /// </summary>
-        internal const int AddressFamilyLength = 1;
+        internal const Int32 AddressFamilyLength = 1;
 
         internal ByteArraySegment data;
 
@@ -60,7 +60,7 @@ namespace PacketDotNet.LLDP
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public NetworkAddress(byte[] bytes, int offset, int length)
+        public NetworkAddress(Byte[] bytes, Int32 offset, Int32 length)
         {
             data = new ByteArraySegment(bytes, offset, length);
         }
@@ -70,7 +70,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Number of bytes in the NetworkAddress
         /// </summary>
-        internal int Length
+        internal Int32 Length
         {
             get
             {
@@ -78,13 +78,13 @@ namespace PacketDotNet.LLDP
             }
         }
 
-        internal byte[] Bytes
+        internal Byte[] Bytes
         {
             get
             {
                 var addressBytes = Address.GetAddressBytes();
-                var data = new byte[AddressFamilyLength + addressBytes.Length];
-                data[0] = (byte)AddressFamily;
+                var data = new Byte[AddressFamilyLength + addressBytes.Length];
+                data[0] = (Byte)AddressFamily;
                 Array.Copy(addressBytes, 0,
                            data, AddressFamilyLength,
                            addressBytes.Length);
@@ -98,12 +98,12 @@ namespace PacketDotNet.LLDP
         public LLDP.AddressFamily AddressFamily
         {
             get { return (LLDP.AddressFamily)data.Bytes[data.Offset]; }
-            set { data.Bytes[data.Offset] = (byte)value; }
+            set { data.Bytes[data.Offset] = (Byte)value; }
         }
 
-        private static int LengthFromAddressFamily(LLDP.AddressFamily addressFamily)
+        private static Int32 LengthFromAddressFamily(LLDP.AddressFamily addressFamily)
         {
-            int length;
+            Int32 length;
 
             if(addressFamily == LLDP.AddressFamily.IPv4)
                 length = IPv4Fields.AddressLength;
@@ -132,7 +132,7 @@ namespace PacketDotNet.LLDP
             get
             {
                 var length = LengthFromAddressFamily(AddressFamily);
-                var bytes = new byte[length];
+                var bytes = new Byte[length];
                 Array.Copy(data.Bytes, data.Offset + AddressFamilyLength,
                            bytes, 0,
                            bytes.Length);
@@ -148,7 +148,7 @@ namespace PacketDotNet.LLDP
 
                 if((data == null) || data.Length != length)
                 {
-                    var bytes = new byte[length];
+                    var bytes = new Byte[length];
                     var offset = 0;
 
                     // allocate enough memory for the new Address
@@ -173,7 +173,7 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A <see cref="System.Boolean"/>
         /// </returns>
-        public override bool Equals (object obj)
+        public override Boolean Equals (Object obj)
         {
             // Check for null values and compare run-time types.
             if (obj == null || GetType() != obj.GetType())
@@ -196,7 +196,7 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A <see cref="System.Int32"/>
         /// </returns>
-        public override int GetHashCode ()
+        public override Int32 GetHashCode ()
         {
             return AddressFamily.GetHashCode() + Address.GetHashCode();
         }
@@ -207,9 +207,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[NetworkAddress: AddressFamily={0}, Address={1}]",
+            return String.Format("[NetworkAddress: AddressFamily={0}, Address={1}]",
                                  AddressFamily, Address);
         }
 

--- a/PacketDotNet/LLDP/OrganizationSpecific.cs
+++ b/PacketDotNet/LLDP/OrganizationSpecific.cs
@@ -42,8 +42,8 @@ namespace PacketDotNet.LLDP
 #pragma warning restore 0169, 0649
 #endif
 
-        private const int OUILength = 3;
-        private const int OUISubTypeLength = 1;
+        private const Int32 OUILength = 3;
+        private const Int32 OUISubTypeLength = 1;
 
         #region Constructors
 
@@ -57,7 +57,7 @@ namespace PacketDotNet.LLDP
         /// The Organization Specific TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public OrganizationSpecific(byte[] bytes, int offset) :
+        public OrganizationSpecific(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {
             log.Debug("");
@@ -75,12 +75,12 @@ namespace PacketDotNet.LLDP
         /// <param name="infoString">
         /// An Organizationally Defined Information String
         /// </param>
-        public OrganizationSpecific(byte[] oui, int subType, byte[] infoString)
+        public OrganizationSpecific(Byte[] oui, Int32 subType, Byte[] infoString)
         {
             log.Debug("");
 
             var length = TLVTypeLength.TypeLengthLength + OUILength + OUISubTypeLength;
-            var bytes = new byte[length];
+            var bytes = new Byte[length];
             var offset = 0;
             tlvData = new ByteArraySegment(bytes, offset, length);
 
@@ -98,11 +98,11 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// An Organizationally Unique Identifier
         /// </summary>
-        public byte[] OrganizationUniqueID
+        public Byte[] OrganizationUniqueID
         {
             get
             {
-                byte[] oui = new byte[OUILength];
+                Byte[] oui = new Byte[OUILength];
                 Array.Copy(tlvData.Bytes, ValueOffset,
                            oui, 0,
                            OUILength);
@@ -119,7 +119,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// An Organizationally Defined SubType
         /// </summary>
-        public int OrganizationDefinedSubType
+        public Int32 OrganizationDefinedSubType
         {
             get
             {
@@ -127,20 +127,20 @@ namespace PacketDotNet.LLDP
             }
             set
             {
-                tlvData.Bytes[ValueOffset + OUILength] = (byte)value;
+                tlvData.Bytes[ValueOffset + OUILength] = (Byte)value;
             }
         }
 
         /// <summary>
         /// An Organizationally Defined Information String
         /// </summary>
-        public byte[] OrganizationDefinedInfoString
+        public Byte[] OrganizationDefinedInfoString
         {
             get
             {
                 var length = Length - (OUILength + OUISubTypeLength);
 
-                var bytes = new byte[length];
+                var bytes = new Byte[length];
                 Array.Copy(tlvData.Bytes, ValueOffset + OUILength + OUISubTypeLength,
                            bytes, 0,
                            length);
@@ -159,7 +159,7 @@ namespace PacketDotNet.LLDP
 
                     // resize the tlv
                     var newLength =  headerLength + value.Length;
-                    var bytes = new byte[newLength];
+                    var bytes = new Byte[newLength];
 
                     // copy the header bytes over
                     Array.Copy(tlvData.Bytes, tlvData.Offset,
@@ -184,9 +184,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A human readable string
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[OrganizationSpecific: OrganizationUniqueID={0}, OrganizationDefinedSubType={1}, OrganizationDefinedInfoString={2}]", OrganizationUniqueID, OrganizationDefinedSubType, OrganizationDefinedInfoString);
+            return String.Format("[OrganizationSpecific: OrganizationUniqueID={0}, OrganizationDefinedSubType={1}, OrganizationDefinedInfoString={2}]", OrganizationUniqueID, OrganizationDefinedSubType, OrganizationDefinedInfoString);
         }
 
         #endregion

--- a/PacketDotNet/LLDP/PortDescription.cs
+++ b/PacketDotNet/LLDP/PortDescription.cs
@@ -51,7 +51,7 @@ namespace PacketDotNet.LLDP
         /// The Port Description TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public PortDescription(byte[] bytes, int offset) :
+        public PortDescription(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {
             log.Debug("");
@@ -63,7 +63,7 @@ namespace PacketDotNet.LLDP
         /// <param name="description">
         /// A textual description of the port
         /// </param>
-        public PortDescription(string description) : base(TLVTypes.PortDescription, description)
+        public PortDescription(String description) : base(TLVTypes.PortDescription, description)
         {
             log.Debug("");
         }
@@ -75,7 +75,7 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// A textual Description of the port
         /// </value>
-        public string Description
+        public String Description
         {
             get { return StringValue; }
             set { StringValue = value; }

--- a/PacketDotNet/LLDP/PortID.cs
+++ b/PacketDotNet/LLDP/PortID.cs
@@ -41,7 +41,7 @@ namespace PacketDotNet.LLDP
 #pragma warning restore 0169, 0649
 #endif
 
-        private const int SubTypeLength = 1;
+        private const Int32 SubTypeLength = 1;
 
         #region Constructors
 
@@ -54,7 +54,7 @@ namespace PacketDotNet.LLDP
         /// The Port ID TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public PortID(byte[] bytes, int offset) :
+        public PortID(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {
             log.Debug("");
@@ -69,7 +69,7 @@ namespace PacketDotNet.LLDP
         /// <param name="subTypeValue">
         /// The subtype's value
         /// </param>
-        public PortID(PortSubTypes subType, object subTypeValue)
+        public PortID(PortSubTypes subType, Object subTypeValue)
         {
             log.Debug("");
 
@@ -93,7 +93,7 @@ namespace PacketDotNet.LLDP
             log.DebugFormat("NetworkAddress {0}", networkAddress.ToString());
 
             var length = TLVTypeLength.TypeLengthLength + SubTypeLength;
-            var bytes = new byte[length];
+            var bytes = new Byte[length];
             var offset = 0;
             tlvData = new ByteArraySegment(bytes, offset, length);
 
@@ -114,14 +114,14 @@ namespace PacketDotNet.LLDP
             get { return (PortSubTypes)tlvData.Bytes[tlvData.Offset + TLVTypeLength.TypeLengthLength]; }
             set
             {
-                tlvData.Bytes[tlvData.Offset + TLVTypeLength.TypeLengthLength] = (byte)value;
+                tlvData.Bytes[tlvData.Offset + TLVTypeLength.TypeLengthLength] = (Byte)value;
             }
         }
 
         /// <value>
         /// The TLV subtype value
         /// </value>
-        public object SubTypeValue
+        public Object SubTypeValue
         {
             get { return GetSubTypeValue(); }
             set { SetSubTypeValue(value); }
@@ -130,7 +130,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Offset to the value field
         /// </summary>
-        private int DataOffset
+        private Int32 DataOffset
         {
             get { return ValueOffset + SubTypeLength; }
         }
@@ -138,7 +138,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Size of the value field
         /// </summary>
-        private int DataLength
+        private Int32 DataLength
         {
             get { return Length - SubTypeLength; }
         }
@@ -153,14 +153,14 @@ namespace PacketDotNet.LLDP
         private void EmptyTLVDataInit()
         {
             var length = TLVTypeLength.TypeLengthLength + SubTypeLength;
-            var bytes = new byte[length];
-            int offset = 0;
+            var bytes = new Byte[length];
+            Int32 offset = 0;
             tlvData = new ByteArraySegment(bytes, offset, length);
         }
 
-        private object GetSubTypeValue()
+        private Object GetSubTypeValue()
         {
-            byte[] arrAddress;
+            Byte[] arrAddress;
 
             switch (SubType)
             {
@@ -170,12 +170,12 @@ namespace PacketDotNet.LLDP
                 case PortSubTypes.PortComponent:
                 case PortSubTypes.AgentCircuitID:
                     // get the address
-                    arrAddress = new byte[DataLength];
+                    arrAddress = new Byte[DataLength];
                     Array.Copy(tlvData.Bytes, DataOffset, arrAddress, 0, DataLength);
                     return arrAddress;
                 case PortSubTypes.MACAddress:
                     // get the address
-                    arrAddress = new byte[DataLength];
+                    arrAddress = new Byte[DataLength];
                     Array.Copy(tlvData.Bytes, DataOffset, arrAddress, 0, DataLength);
                     PhysicalAddress address = new PhysicalAddress(arrAddress);
                     return address;
@@ -188,7 +188,7 @@ namespace PacketDotNet.LLDP
             }
         }
 
-        private void SetSubTypeValue(object subTypeValue)
+        private void SetSubTypeValue(Object subTypeValue)
         {
             switch (SubType)
             {
@@ -197,7 +197,7 @@ namespace PacketDotNet.LLDP
                 case PortSubTypes.LocallyAssigned:
                 case PortSubTypes.PortComponent:
                 case PortSubTypes.AgentCircuitID:
-                    SetSubTypeValue((byte[])subTypeValue);
+                    SetSubTypeValue((Byte[])subTypeValue);
                     break;
                 case PortSubTypes.MACAddress:
                     SetSubTypeValue(((PhysicalAddress)subTypeValue).GetAddressBytes());
@@ -210,15 +210,15 @@ namespace PacketDotNet.LLDP
             }
         }
 
-        private void SetSubTypeValue(byte[] val)
+        private void SetSubTypeValue(Byte[] val)
         {
             // does our current length match?
-            int dataLength = Length - SubTypeLength;
+            Int32 dataLength = Length - SubTypeLength;
             if(dataLength != val.Length)
             {
                 var headerLength = TLVTypeLength.TypeLengthLength + SubTypeLength;
                 var newLength = headerLength + val.Length;
-                var newBytes = new byte[newLength];
+                var newBytes = new Byte[newLength];
 
                 // copy the header data over
                 Array.Copy(tlvData.Bytes, tlvData.Offset,
@@ -252,9 +252,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A human readable string
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[PortID: SubType={0}, SubTypeValue={1}]", SubType, SubTypeValue);
+            return String.Format("[PortID: SubType={0}, SubTypeValue={1}]", SubType, SubTypeValue);
         }
 
         #endregion

--- a/PacketDotNet/LLDP/StringTLV.cs
+++ b/PacketDotNet/LLDP/StringTLV.cs
@@ -40,7 +40,7 @@ namespace PacketDotNet.LLDP
         /// The Port Description TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public StringTLV(byte[] bytes, int offset) :
+        public StringTLV(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {}
 
@@ -53,9 +53,9 @@ namespace PacketDotNet.LLDP
         /// <param name="StringValue">
         /// A <see cref="System.String"/>
         /// </param>
-        public StringTLV(TLVTypes tlvType, string StringValue)
+        public StringTLV(TLVTypes tlvType, String StringValue)
         {
-            var bytes = new byte[TLVTypeLength.TypeLengthLength];
+            var bytes = new Byte[TLVTypeLength.TypeLengthLength];
             var offset = 0;
             tlvData = new ByteArraySegment(bytes, offset, bytes.Length);
 
@@ -70,7 +70,7 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// A textual Description of the port
         /// </value>
-        public string StringValue
+        public String StringValue
         {
             get
             {
@@ -88,7 +88,7 @@ namespace PacketDotNet.LLDP
                 if(tlvData.Length != length)
                 {
                     // allocate new memory for this tlv
-                    var newTLVBytes = new byte[length];
+                    var newTLVBytes = new Byte[length];
                     var offset = 0;
 
                     // copy header over
@@ -112,9 +112,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A human readable string
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[{0}: Description={1}]", Type, StringValue);
+            return String.Format("[{0}: Description={1}]", Type, StringValue);
         }
 
         #endregion

--- a/PacketDotNet/LLDP/SystemCapabilities.cs
+++ b/PacketDotNet/LLDP/SystemCapabilities.cs
@@ -32,8 +32,8 @@ namespace PacketDotNet.LLDP
     [Serializable]
     public class SystemCapabilities : TLV
     {
-        private const int SystemCapabilitiesLength = 2;
-        private const int EnabledCapabilitiesLength = 2;
+        private const Int32 SystemCapabilitiesLength = 2;
+        private const Int32 EnabledCapabilitiesLength = 2;
 
         #region Constructors
 
@@ -46,7 +46,7 @@ namespace PacketDotNet.LLDP
         /// The System Capabilities TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public SystemCapabilities(byte[] bytes, int offset) :
+        public SystemCapabilities(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {}
 
@@ -59,10 +59,10 @@ namespace PacketDotNet.LLDP
         /// <param name="enabled">
         /// A bitmap containing the enabled System Capabilities
         /// </param>
-        public SystemCapabilities(ushort capabilities, ushort enabled)
+        public SystemCapabilities(UInt16 capabilities, UInt16 enabled)
         {
             var length = TLVTypeLength.TypeLengthLength + SystemCapabilitiesLength + EnabledCapabilitiesLength;
-            var bytes = new byte[length];
+            var bytes = new Byte[length];
             var offset = 0;
             tlvData = new ByteArraySegment(bytes, offset, length);
 
@@ -78,7 +78,7 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// A bitmap containing the available System Capabilities
         /// </value>
-        public ushort Capabilities
+        public UInt16 Capabilities
         {
             get
             {
@@ -98,7 +98,7 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// A bitmap containing the Enabled System Capabilities
         /// </value>
-        public ushort Enabled
+        public UInt16 Enabled
         {
             get
             {
@@ -128,9 +128,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// Whether or not the system is capable of the function being tested
         /// </returns>
-        public bool IsCapable(CapabilityOptions capability)
+        public Boolean IsCapable(CapabilityOptions capability)
         {
-            ushort mask = (ushort)capability;
+            UInt16 mask = (UInt16)capability;
             if ((Capabilities & mask) != 0)
             {
                 return true;
@@ -150,9 +150,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// Whether or not the specified function is enabled
         /// </returns>
-        public bool IsEnabled(CapabilityOptions capability)
+        public Boolean IsEnabled(CapabilityOptions capability)
         {
-            ushort mask = (ushort)capability;
+            UInt16 mask = (UInt16)capability;
             if ((Enabled & mask) != 0)
             {
                 return true;
@@ -169,9 +169,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A human readable string
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[SystemCapabilities: Capabilities={0}, Enabled={1}]", Capabilities, Enabled);
+            return String.Format("[SystemCapabilities: Capabilities={0}, Enabled={1}]", Capabilities, Enabled);
         }
 
         #endregion

--- a/PacketDotNet/LLDP/SystemDescription.cs
+++ b/PacketDotNet/LLDP/SystemDescription.cs
@@ -50,7 +50,7 @@ namespace PacketDotNet.LLDP
         /// The System Description TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public SystemDescription(byte[] bytes, int offset) :
+        public SystemDescription(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {
             log.Debug("");
@@ -62,7 +62,7 @@ namespace PacketDotNet.LLDP
         /// <param name="description">
         /// A textual Description of the system
         /// </param>
-        public SystemDescription(string description) : base(TLVTypes.SystemDescription,
+        public SystemDescription(String description) : base(TLVTypes.SystemDescription,
                                                             description)
         {
             log.Debug("");
@@ -75,7 +75,7 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// A textual Description of the system
         /// </value>
-        public string Description
+        public String Description
         {
             get { return StringValue; }
             set { StringValue = value; }

--- a/PacketDotNet/LLDP/SystemName.cs
+++ b/PacketDotNet/LLDP/SystemName.cs
@@ -40,7 +40,7 @@ namespace PacketDotNet.LLDP
         /// The System Name TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public SystemName(byte[] bytes, int offset) :
+        public SystemName(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {}
 
@@ -50,7 +50,7 @@ namespace PacketDotNet.LLDP
         /// <param name="name">
         /// A textual Name of the system
         /// </param>
-        public SystemName(string name) : base(TLVTypes.SystemName, name)
+        public SystemName(String name) : base(TLVTypes.SystemName, name)
         {
         }
 
@@ -61,7 +61,7 @@ namespace PacketDotNet.LLDP
         /// <value>
         /// A textual Name of the system
         /// </value>
-        public string Name
+        public String Name
         {
             get { return StringValue; }
             set { StringValue = value; }

--- a/PacketDotNet/LLDP/TLV.cs
+++ b/PacketDotNet/LLDP/TLV.cs
@@ -58,7 +58,7 @@ namespace PacketDotNet.LLDP
         /// <param name="offset">
         /// The TLVs offset from the start of byte[] bytes
         /// </param>
-        public TLV(byte[] bytes, int offset)
+        public TLV(Byte[] bytes, Int32 offset)
         {
             // setup a local ByteArrayAndOffset in order to retrieve the value length
             // NOTE: we cannot set tlvData to retrieve the value length as
@@ -84,7 +84,7 @@ namespace PacketDotNet.LLDP
         /// Length of value portion of the TLV
         /// NOTE: Does not include the length of the Type and Length fields
         /// </summary>
-        public int Length
+        public Int32 Length
         {
             get { return TypeLength.Length; }
 
@@ -96,7 +96,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Total length of the TLV, including the length of the Type and Length fields
         /// </summary>
-        public int TotalLength
+        public Int32 TotalLength
         {
             get { return tlvData.Length; }
         }
@@ -118,7 +118,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Offset to the value bytes of the TLV
         /// </summary>
-        internal int ValueOffset
+        internal Int32 ValueOffset
         {
             get { return tlvData.Offset + TLVTypeLength.TypeLengthLength; }
         }
@@ -126,7 +126,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Return a byte[] that contains the tlv
         /// </summary>
-        public virtual byte[] Bytes
+        public virtual Byte[] Bytes
         {
             get
             {

--- a/PacketDotNet/LLDP/TLVCollection.cs
+++ b/PacketDotNet/LLDP/TLVCollection.cs
@@ -57,7 +57,7 @@ namespace PacketDotNet
         /// <param name="item">
         /// A <see cref="TLV"/>
         /// </param>
-        protected override void InsertItem (int index, TLV item)
+        protected override void InsertItem (Int32 index, TLV item)
         {
             log.DebugFormat("index {0}, TLV.GetType {1}, TLV.Type {2}",
                             index, item.GetType(), item.Type);
@@ -84,7 +84,7 @@ namespace PacketDotNet
 
             // if we have no items insert the first item wherever
             // if we have items insert the item befor the last item as the last item is a EndOfLLDPDU
-            int insertPosition = (Count == 0) ? 0 : Count - 1;
+            Int32 insertPosition = (Count == 0) ? 0 : Count - 1;
 
             log.DebugFormat("Inserting item at position {0}", insertPosition);
 

--- a/PacketDotNet/LLDP/TLVTypeLength.cs
+++ b/PacketDotNet/LLDP/TLVTypeLength.cs
@@ -44,14 +44,14 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Length in bytes of the tlv type and length fields
         /// </summary>
-        public const int TypeLengthLength = 2;
+        public const Int32 TypeLengthLength = 2;
 
-        private const int TypeBits = 7;
-        private const int TypeMask = 0xFE00;
-        private const int LengthBits = 9;
-        private const int LengthMask = 0x1FF;
+        private const Int32 TypeBits = 7;
+        private const Int32 TypeMask = 0xFE00;
+        private const Int32 LengthBits = 9;
+        private const Int32 LengthMask = 0x1FF;
 
-        private const int MaximumTLVLength = 511;
+        private const Int32 MaximumTLVLength = 511;
 
         private ByteArraySegment byteArraySegment;
 
@@ -74,7 +74,7 @@ namespace PacketDotNet.LLDP
             get
             {
                 // get the type
-                ushort typeAndLength = TypeAndLength;
+                UInt16 typeAndLength = TypeAndLength;
                 // remove the length info
                 return (TLVTypes)(typeAndLength >> LengthBits);
             }
@@ -84,11 +84,11 @@ namespace PacketDotNet.LLDP
                 log.DebugFormat("value of {0}", value);
 
                 // shift type into the type position
-                var type = (ushort)((ushort)value << LengthBits);
+                var type = (UInt16)((UInt16)value << LengthBits);
                 // save the old length
-                ushort length = (ushort)(LengthMask & TypeAndLength);
+                UInt16 length = (UInt16)(LengthMask & TypeAndLength);
                 // set the type
-                TypeAndLength = (ushort)(type | length);
+                TypeAndLength = (UInt16)(type | length);
             }
         }
 
@@ -97,12 +97,12 @@ namespace PacketDotNet.LLDP
         /// NOTE: Value is the length of the TLV Value only, does not include the length
         ///       of the type and length fields
         /// </value>
-        public int Length
+        public Int32 Length
         {
             get
             {
                 // get the length
-                ushort typeAndLength = TypeAndLength;
+                UInt16 typeAndLength = TypeAndLength;
                 // remove the type info
                 return LengthMask & typeAndLength;
             }
@@ -117,16 +117,16 @@ namespace PacketDotNet.LLDP
                 if(value > MaximumTLVLength) { throw new ArgumentOutOfRangeException("Length", "The maximum value for a TLV length is 511"); }
 
                 // save the old type
-                ushort type = (ushort)(TypeMask & TypeAndLength);
+                UInt16 type = (UInt16)(TypeMask & TypeAndLength);
                 // set the length
-                TypeAndLength = (ushort)(type | value);
+                TypeAndLength = (UInt16)(type | value);
             }
         }
 
         /// <value>
         /// A unsigned short representing the concatenated Type and Length
         /// </value>
-        private ushort TypeAndLength
+        private UInt16 TypeAndLength
         {
             get
             {

--- a/PacketDotNet/LLDP/TimeToLive.cs
+++ b/PacketDotNet/LLDP/TimeToLive.cs
@@ -43,7 +43,7 @@ namespace PacketDotNet.LLDP
         /// <summary>
         /// Number of bytes in the value portion of this tlv
         /// </summary>
-        private const int ValueLength = 2;
+        private const Int32 ValueLength = 2;
 
         #region Constructors
 
@@ -56,7 +56,7 @@ namespace PacketDotNet.LLDP
         /// The TTL TLV's offset from the
         /// origin of the LLDP
         /// </param>
-        public TimeToLive(byte[] bytes, int offset) :
+        public TimeToLive(Byte[] bytes, Int32 offset) :
             base(bytes, offset)
         {
             log.Debug("");
@@ -69,13 +69,13 @@ namespace PacketDotNet.LLDP
         /// The length in seconds until the LLDP
         /// is refreshed
         /// </param>
-        public TimeToLive(ushort seconds)
+        public TimeToLive(UInt16 seconds)
         {
             log.Debug("");
 
-            var bytes = new byte[TLVTypeLength.TypeLengthLength + ValueLength];
-            int offset = 0;
-            int length = bytes.Length;
+            var bytes = new Byte[TLVTypeLength.TypeLengthLength + ValueLength];
+            Int32 offset = 0;
+            Int32 length = bytes.Length;
             tlvData = new ByteArraySegment(bytes, offset, length);
 
             Type = TLVTypes.TimeToLive;
@@ -93,7 +93,7 @@ namespace PacketDotNet.LLDP
         /// A value of 0 means that the LLDP source is
         /// closed and should no longer be refreshed
         /// </value>
-        public ushort Seconds
+        public UInt16 Seconds
         {
             get
             {
@@ -115,9 +115,9 @@ namespace PacketDotNet.LLDP
         /// <returns>
         /// A human readable string
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[TimeToLive: Seconds={0}]", Seconds);
+            return String.Format("[TimeToLive: Seconds={0}]", Seconds);
         }
 
         #endregion

--- a/PacketDotNet/LLDPPacket.cs
+++ b/PacketDotNet/LLDPPacket.cs
@@ -94,7 +94,7 @@ namespace PacketDotNet
         /// <value>
         /// The current length of the LLDPDU
         /// </value>
-        public int Length
+        public Int32 Length
         {
             get { return _Length; }
             set { _Length = value; }
@@ -131,7 +131,7 @@ namespace PacketDotNet
         /// </summary>
         /// <param name="index">The index of the item being set/retrieved in the collection</param>
         /// <returns>The requested TLV</returns>
-        public TLV this[int index]
+        public TLV this[Int32 index]
         {
             get { return TlvCollection[index]; }
             set { TlvCollection[index] = value; }
@@ -153,11 +153,11 @@ namespace PacketDotNet
         /// <summary>
         /// Parse byte[] into TLVs
         /// </summary>
-        public void ParseByteArrayIntoTlvs(byte[] bytes, int offset)
+        public void ParseByteArrayIntoTlvs(Byte[] bytes, Int32 offset)
         {
             log.DebugFormat("bytes.Length {0}, offset {1}", bytes.Length, offset);
 
-            int position = 0;
+            Int32 position = 0;
 
             TlvCollection.Clear();
 
@@ -208,7 +208,7 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="TLV"/>
         /// </returns>
-        private static TLV TLVFactory(byte[] Bytes, int offset, TLVTypes type)
+        private static TLV TLVFactory(Byte[] Bytes, Int32 offset, TLVTypes type)
         {
             switch(type)
             {
@@ -249,16 +249,16 @@ namespace PacketDotNet
 
             var lldpPacket = new LLDPPacket();
 
-            byte[] physicalAddressBytes = new byte[EthernetFields.MacAddressLength];
+            Byte[] physicalAddressBytes = new Byte[EthernetFields.MacAddressLength];
             rnd.NextBytes(physicalAddressBytes);
             var physicalAddress = new PhysicalAddress(physicalAddressBytes);
             lldpPacket.TlvCollection.Add(new ChassisID(physicalAddress));
 
-            byte[] networkAddress = new byte[IPv4Fields.AddressLength];
+            Byte[] networkAddress = new Byte[IPv4Fields.AddressLength];
             rnd.NextBytes(networkAddress);
             lldpPacket.TlvCollection.Add(new PortID(new NetworkAddress(new IPAddress(networkAddress))));
 
-            ushort seconds = (ushort)rnd.Next(0,120);
+            UInt16 seconds = (UInt16)rnd.Next(0,120);
             lldpPacket.TlvCollection.Add(new TimeToLive(seconds));
 
             lldpPacket.TlvCollection.Add(new EndOfLLDPDU());
@@ -267,11 +267,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -282,7 +282,7 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Normal || outputFormat == StringOutputType.Colored)
             {
                 // build the string of tlvs
-                string tlvs = "{";
+                String tlvs = "{";
                 var r = new Regex(@"[^(\.)]([^\.]*)$");
                 foreach(TLV tlv in TlvCollection)
                 {
@@ -329,7 +329,7 @@ namespace PacketDotNet
         /// </summary>
         public TLVCollection TlvCollection = new TLVCollection();
 
-        int _Length;
+        Int32 _Length;
 
         #endregion
     }

--- a/PacketDotNet/LSA.cs
+++ b/PacketDotNet/LSA.cs
@@ -34,27 +34,27 @@ namespace PacketDotNet
     public struct TOSMetric
     {
         ///<summary>The number of bytes a TOS metric occupy</summary>
-        public static readonly int TOSMetricLength = 4;
+        public static readonly Int32 TOSMetricLength = 4;
 
         /// <summary>
         /// IP Type of Service that this metric refers to.
         /// </summary>
-        public byte TOS;
+        public Byte TOS;
 
         /// <summary>
         /// TOS-specific metric information.
         /// </summary>
-        public uint Metric;
+        public UInt32 Metric;
 
         /// <summary>
         /// Gets the bytes that make up this packet.
         /// </summary>
         /// <value>Packet bytes</value>
-        public byte[] Bytes
+        public Byte[] Bytes
         {
             get
             {
-                byte[] b = new byte[TOSMetricLength];
+                Byte[] b = new Byte[TOSMetricLength];
                 EndianBitConverter.Big.CopyBytes(Metric, b, 0);
                 b[0] = TOS;
                 return b;
@@ -71,7 +71,7 @@ namespace PacketDotNet
         /// <summary>
         /// Size of LinkStateRequest in bytes
         /// </summary>
-        public static readonly int Length = 12;
+        public static readonly Int32 Length = 12;
 
         internal ByteArraySegment header;
 
@@ -80,7 +80,7 @@ namespace PacketDotNet
         /// </summary>
         public LinkStateRequest()
         {
-            byte[] b = new byte[LinkStateRequest.Length];
+            Byte[] b = new Byte[LinkStateRequest.Length];
             this.header = new ByteArraySegment(b);
         }
 
@@ -96,7 +96,7 @@ namespace PacketDotNet
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public LinkStateRequest(byte[] packet, int offset, int length)
+        public LinkStateRequest(Byte[] packet, Int32 offset, Int32 length)
         {
             this.header = new ByteArraySegment(packet, offset, length);
         }
@@ -128,7 +128,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + LinkStateRequestFields.AdvertisingRouterPosition,
                            address.Length);
@@ -148,7 +148,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + LinkStateRequestFields.LinkStateIdPosition,
                            address.Length);
@@ -159,7 +159,7 @@ namespace PacketDotNet
         /// Gets the bytes.
         /// </summary>
         /// <value>The bytes.</value>
-        public virtual byte[] Bytes
+        public virtual Byte[] Bytes
         {
             get
             {
@@ -182,19 +182,19 @@ namespace PacketDotNet
         /// <summary>
         /// The I pv4 bytes count.
         /// </summary>
-        public const int IPv4BytesCount = 4;
+        public const Int32 IPv4BytesCount = 4;
 
         /// <summary>
         /// The length of the network mask.
         /// </summary>
-        public const int NetworkMaskLength = 4;
+        public const Int32 NetworkMaskLength = 4;
 
         /// <summary>
         /// Default constructor
         /// </summary>
         public LSA()
         {
-            byte[] b = new byte[OSPFv2Fields.LSAHeaderLength];
+            Byte[] b = new Byte[OSPFv2Fields.LSAHeaderLength];
             this.header = new ByteArraySegment(b);
         }
 
@@ -210,7 +210,7 @@ namespace PacketDotNet
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public LSA(byte[] packet, int offset, int length)
+        public LSA(Byte[] packet, Int32 offset, Int32 length)
         {
             this.header = new ByteArraySegment(packet, offset, length);
         }
@@ -218,7 +218,7 @@ namespace PacketDotNet
         /// <summary>
         /// The time in seconds since the LSA was originated.
         /// </summary>
-        public ushort LSAge
+        public UInt16 LSAge
         {
             get
             {
@@ -233,7 +233,7 @@ namespace PacketDotNet
         /// <summary>
         /// The optional capabilities supported by the described portion of the routing domain.
         /// </summary>
-        public byte Options
+        public Byte Options
         {
             get
             {
@@ -256,7 +256,7 @@ namespace PacketDotNet
             }
             set
             {
-                header.Bytes[header.Offset + LSAFields.LSTypePosition] = (byte)value;
+                header.Bytes[header.Offset + LSAFields.LSTypePosition] = (Byte)value;
             }
         }
 
@@ -276,7 +276,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + LSAFields.LinkStateIDPosition,
                            address.Length);
@@ -295,7 +295,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + LSAFields.AdvertisingRouterIDPosition,
                            address.Length);
@@ -306,7 +306,7 @@ namespace PacketDotNet
         /// Detects old or duplicate LSAs.  Successive instances of an LSA
         /// are given successive LS sequence numbers.
         /// </summary>
-        public uint LSSequenceNumber
+        public UInt32 LSSequenceNumber
         {
             get
             {
@@ -322,7 +322,7 @@ namespace PacketDotNet
         /// The Fletcher checksum of the complete contents of the LSA,
         /// including the LSA header but excluding the LS age field.
         /// </summary>
-        public ushort Checksum
+        public UInt16 Checksum
         {
             get
             {
@@ -338,7 +338,7 @@ namespace PacketDotNet
         /// The length in bytes of the LSA.  This includes the 20 byte LSA
         /// header.
         /// </summary>
-        public ushort Length
+        public UInt16 Length
         {
             get
             {
@@ -354,7 +354,7 @@ namespace PacketDotNet
         /// Returns a <see cref="System.String"/> that represents the current <see cref="PacketDotNet.LSA"/>.
         /// </summary>
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="PacketDotNet.LSA"/>.</returns>
-        public override string ToString()
+        public override String ToString()
         {
             StringBuilder builder = new StringBuilder();
             builder.AppendFormat("LSA Type {0}, Checksum {1:X2}\n", this.LSType, this.Checksum);
@@ -365,7 +365,7 @@ namespace PacketDotNet
         /// Gets the bytes.
         /// </summary>
         /// <value>The bytes.</value>
-        public virtual byte[] Bytes
+        public virtual Byte[] Bytes
         {
             get
             {
@@ -383,7 +383,7 @@ namespace PacketDotNet
         /// <summary>
         /// The length of the router link.
         /// </summary>
-        public static readonly int RouterLinkLength = 12;
+        public static readonly Int32 RouterLinkLength = 12;
         internal ByteArraySegment header;
 
         /// <summary>
@@ -391,7 +391,7 @@ namespace PacketDotNet
         /// </summary>
         public RouterLink()
         {
-            byte[] b = new byte[RouterLinkLength];
+            Byte[] b = new Byte[RouterLinkLength];
             this.header = new ByteArraySegment(b);
         }
 
@@ -400,9 +400,9 @@ namespace PacketDotNet
         /// </summary>
         public RouterLink(List<TOSMetric> metrics)
         {
-            int length = RouterLinkLength + metrics.Count * TOSMetric.TOSMetricLength;
-            int offset = RouterLinkFields.AdditionalMetricsPosition;
-            byte[] b = new byte[length];
+            Int32 length = RouterLinkLength + metrics.Count * TOSMetric.TOSMetricLength;
+            Int32 offset = RouterLinkFields.AdditionalMetricsPosition;
+            Byte[] b = new Byte[length];
 
             foreach (TOSMetric m in metrics)
             {
@@ -425,7 +425,7 @@ namespace PacketDotNet
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public RouterLink(byte[] packet, int offset, int length)
+        public RouterLink(Byte[] packet, Int32 offset, Int32 length)
         {
             this.header = new ByteArraySegment(packet, offset, length);
         }
@@ -444,7 +444,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + RouterLinkFields.LinkIDPosition,
                            address.Length);
@@ -463,7 +463,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + RouterLinkFields.LinkDataPosition,
                            address.Length);
@@ -473,7 +473,7 @@ namespace PacketDotNet
         /// <summary>
         /// A quick description of the router link. See http://www.ietf.org/rfc/rfc2328.txt for details.
         /// </summary>
-        public byte Type
+        public Byte Type
         {
             get
             {
@@ -489,7 +489,7 @@ namespace PacketDotNet
         /// The number of different TOS metrics given for this link, not
         /// counting the required link metric
         /// </summary>
-        public byte TOSNumber
+        public Byte TOSNumber
         {
             get
             {
@@ -504,7 +504,7 @@ namespace PacketDotNet
         /// <summary>
         /// The cost of using this router link.
         /// </summary>
-        public ushort Metric
+        public UInt16 Metric
         {
             get
             {
@@ -525,11 +525,11 @@ namespace PacketDotNet
             {
                 List<TOSMetric> metrics = new List<TOSMetric>();
 
-                for (int i = 0; i < this.TOSNumber; i++)
+                for (Int32 i = 0; i < this.TOSNumber; i++)
                 {
                     var metric = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + RouterLinkFields.AdditionalMetricsPosition + i * TOSMetric.TOSMetricLength);
                     TOSMetric m = new TOSMetric();
-                    m.TOS = (byte)((metric & 0xFF000000) >> 3);
+                    m.TOS = (Byte)((metric & 0xFF000000) >> 3);
                     m.Metric = metric & 0x00FFFFFF;
                     metrics.Add(m);
                 }
@@ -540,7 +540,7 @@ namespace PacketDotNet
         /// <summary>
         /// bytes representation
         /// </summary>
-        public byte[] Bytes
+        public Byte[] Bytes
         {
             get
             {
@@ -565,11 +565,11 @@ namespace PacketDotNet
         /// </summary>
         public RouterLSA()
         {
-            byte[] b = new byte[RouterLSAFields.RouterLinksStart];
+            Byte[] b = new Byte[RouterLSAFields.RouterLinksStart];
             this.header = new ByteArraySegment(b);
             this.LSType = lsaType;
             this.LinkNumber = 0;
-            this.Length = (ushort)this.header.Bytes.Length;
+            this.Length = (UInt16)this.header.Bytes.Length;
         }
 
         /// <summary>
@@ -577,15 +577,15 @@ namespace PacketDotNet
         /// </summary>
         public RouterLSA(List<RouterLink> links)
         {
-            int length = 0;
-            int offset = RouterLSAFields.RouterLinksStart;
+            Int32 length = 0;
+            Int32 offset = RouterLSAFields.RouterLinksStart;
             foreach (RouterLink l in links)
             {
                 length += l.Bytes.Length;
             }
             length += RouterLSAFields.RouterLinksStart;
 
-            byte[] b = new byte[length];
+            Byte[] b = new Byte[length];
             this.header = new ByteArraySegment(b);
             foreach (RouterLink l in links)
             {
@@ -594,8 +594,8 @@ namespace PacketDotNet
             }
 
             this.LSType = lsaType;
-            this.LinkNumber = (ushort)links.Count;
-            this.Length = (ushort)this.header.Bytes.Length;
+            this.LinkNumber = (UInt16)links.Count;
+            this.Length = (UInt16)this.header.Bytes.Length;
         }
 
         /// <summary>
@@ -610,7 +610,7 @@ namespace PacketDotNet
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public RouterLSA(byte[] packet, int offset, int length) :
+        public RouterLSA(Byte[] packet, Int32 offset, Int32 length) :
             base(packet, offset, length)
         {
 
@@ -620,55 +620,55 @@ namespace PacketDotNet
         /// When set, the router is an endpoint of one or more fully
         /// adjacent virtual links having the described area as Transit area
         /// </summary>
-        public int vBit
+        public Int32 vBit
         {
             get
             {
-                byte flags = (byte)((header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] >> 2) & 1);
+                Byte flags = (Byte)((header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] >> 2) & 1);
                 return flags;
             }
             set
             {
-                header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] |= (byte)((value & 1) << 2);
+                header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] |= (Byte)((value & 1) << 2);
             }
         }
 
         /// <summary>
         /// When set, the router is an AS boundary router
         /// </summary>
-        public int eBit
+        public Int32 eBit
         {
             get
             {
-                byte flags = (byte)((header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] >> 1) & 1);
+                Byte flags = (Byte)((header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] >> 1) & 1);
                 return flags;
             }
             set
             {
-                header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] |= (byte)((value & 1) << 1);
+                header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] |= (Byte)((value & 1) << 1);
             }
         }
 
         /// <summary>
         /// When set, the router is an area border router
         /// </summary>
-        public int bBit
+        public Int32 bBit
         {
             get
             {
-                byte flags = (byte)(header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] & 1);
+                Byte flags = (Byte)(header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] & 1);
                 return flags;
             }
             set
             {
-                header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] |= (byte)(value & 1);
+                header.Bytes[header.Offset + RouterLSAFields.RouterOptionsPosition] |= (Byte)(value & 1);
             }
         }
 
         /// <summary>
         /// The number of the contained links in this RouterLSA
         /// </summary>
-        public ushort LinkNumber
+        public UInt16 LinkNumber
         {
             get
             {
@@ -691,9 +691,9 @@ namespace PacketDotNet
             {
                 List<RouterLink> ret = new List<RouterLink>();
 
-                int offset = this.header.Offset + RouterLSAFields.RouterLinksStart;
+                Int32 offset = this.header.Offset + RouterLSAFields.RouterLinksStart;
 
-                for (int i = 0; i < this.LinkNumber; i++)
+                for (Int32 i = 0; i < this.LinkNumber; i++)
                 {
                     RouterLink l = new RouterLink(header.Bytes, offset, RouterLink.RouterLinkLength);
                     ret.Add(l);
@@ -708,7 +708,7 @@ namespace PacketDotNet
         /// Returns a <see cref="System.String"/> that represents the current <see cref="PacketDotNet.RouterLSA"/>.
         /// </summary>
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="PacketDotNet.RouterLSA"/>.</returns>
-        public override string ToString()
+        public override String ToString()
         {
             StringBuilder ret = new StringBuilder();
             ret.Append("Router LSA, ");
@@ -735,10 +735,10 @@ namespace PacketDotNet
         /// </summary>
         public NetworkLSA()
         {
-            byte[] b = new byte[NetworkLSAFields.AttachedRouterPosition];
+            Byte[] b = new Byte[NetworkLSAFields.AttachedRouterPosition];
             this.header = new ByteArraySegment(b);
             this.LSType = lsaType;
-            this.Length = (ushort)this.header.Bytes.Length;
+            this.Length = (UInt16)this.header.Bytes.Length;
         }
 
         /// <summary>
@@ -746,10 +746,10 @@ namespace PacketDotNet
         /// </summary>
         public NetworkLSA(List<IPAddress> routers)
         {
-            int length = NetworkLSAFields.AttachedRouterPosition + routers.Count * IPv4BytesCount;
-            int offset = NetworkLSAFields.AttachedRouterPosition;
+            Int32 length = NetworkLSAFields.AttachedRouterPosition + routers.Count * IPv4BytesCount;
+            Int32 offset = NetworkLSAFields.AttachedRouterPosition;
 
-            byte[] b = new byte[length];
+            Byte[] b = new Byte[length];
             foreach (IPAddress ip in routers)
             {
                 Array.Copy(ip.GetAddressBytes(), 0, b, offset, IPv4BytesCount);
@@ -758,7 +758,7 @@ namespace PacketDotNet
 
             this.header = new ByteArraySegment(b);
             this.LSType = lsaType;
-            this.Length = (ushort)this.header.Bytes.Length;
+            this.Length = (UInt16)this.header.Bytes.Length;
         }
 
         /// <summary>
@@ -773,7 +773,7 @@ namespace PacketDotNet
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public NetworkLSA(byte[] packet, int offset, int length) :
+        public NetworkLSA(Byte[] packet, Int32 offset, Int32 length) :
             base(packet, offset, length)
         {
 
@@ -793,7 +793,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + NetworkLSAFields.NetworkMaskPosition,
                            address.Length);
@@ -812,7 +812,7 @@ namespace PacketDotNet
             get
             {
                 List<IPAddress> ret = new List<IPAddress>();
-                int routerCount = this.Length - NetworkMaskLength - OSPFv2Fields.LSAHeaderLength;
+                Int32 routerCount = this.Length - NetworkMaskLength - OSPFv2Fields.LSAHeaderLength;
                 if (routerCount % IPv4BytesCount != 0)
                 {
                     throw new Exception("Mallformed NetworkLSA - routerCount should be aligned to 4");
@@ -820,9 +820,9 @@ namespace PacketDotNet
 
                 routerCount /= IPv4BytesCount;
 
-                for (int i = 0; i < routerCount; i++)
+                for (Int32 i = 0; i < routerCount; i++)
                 {
-                    byte[] adr = new byte[IPv4BytesCount];
+                    Byte[] adr = new Byte[IPv4BytesCount];
                     Array.Copy(header.Bytes, header.Offset + NetworkLSAFields.AttachedRouterPosition + i * IPv4BytesCount, adr, 0, IPv4BytesCount);
                     IPAddress ip = new IPAddress(adr);
                     ret.Add(ip);
@@ -851,10 +851,10 @@ namespace PacketDotNet
         /// </summary>
         public SummaryLSA()
         {
-            byte[] b = new byte[SummaryLSAFields.TOSMetricPosition];
+            Byte[] b = new Byte[SummaryLSAFields.TOSMetricPosition];
             this.header = new ByteArraySegment(b);
             this.LSType = lsaType;
-            this.Length = (ushort)this.header.Bytes.Length;
+            this.Length = (UInt16)this.header.Bytes.Length;
         }
 
         /// <summary>
@@ -862,9 +862,9 @@ namespace PacketDotNet
         /// </summary>
         public SummaryLSA(List<TOSMetric> metrics)
         {
-            int length = SummaryLSAFields.TOSMetricPosition + metrics.Count * TOSMetric.TOSMetricLength;
-            int offset = SummaryLSAFields.TOSMetricPosition;
-            byte[] b = new byte[length];
+            Int32 length = SummaryLSAFields.TOSMetricPosition + metrics.Count * TOSMetric.TOSMetricLength;
+            Int32 offset = SummaryLSAFields.TOSMetricPosition;
+            Byte[] b = new Byte[length];
 
             foreach (TOSMetric m in metrics)
             {
@@ -874,7 +874,7 @@ namespace PacketDotNet
 
             this.header = new ByteArraySegment(b);
             this.LSType = lsaType;
-            this.Length = (ushort)this.header.Bytes.Length;
+            this.Length = (UInt16)this.header.Bytes.Length;
         }
 
         /// <summary>
@@ -889,7 +889,7 @@ namespace PacketDotNet
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public SummaryLSA(byte[] packet, int offset, int length) :
+        public SummaryLSA(Byte[] packet, Int32 offset, Int32 length) :
             base(packet, offset, length)
         {
 
@@ -909,7 +909,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + SummaryLSAFields.NetworkMaskPosition,
                            address.Length);
@@ -919,7 +919,7 @@ namespace PacketDotNet
         /// <summary>
         /// The cost of this route.  Expressed in the same units as the interface costs in the router-LSAs.
         /// </summary>
-        public uint Metric
+        public UInt32 Metric
         {
             get
             {
@@ -948,13 +948,13 @@ namespace PacketDotNet
                     throw new Exception("Malformed summary LSA - bad TOSMetrics size");
                 }
 
-                int tosCnt = (this.Length - SummaryLSAFields.TOSMetricPosition) / TOSMetric.TOSMetricLength;
+                Int32 tosCnt = (this.Length - SummaryLSAFields.TOSMetricPosition) / TOSMetric.TOSMetricLength;
 
-                for (int i = 0; i < tosCnt; i++)
+                for (Int32 i = 0; i < tosCnt; i++)
                 {
                     var metric = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + SummaryLSAFields.TOSMetricPosition + i * TOSMetric.TOSMetricLength);
                     TOSMetric m = new TOSMetric();
-                    m.TOS = (byte)((metric & 0xFF000000) >> 24);
+                    m.TOS = (Byte)((metric & 0xFF000000) >> 24);
                     m.Metric = metric & 0x00FFFFFF;
                     ret.Add(m);
                 }
@@ -971,7 +971,7 @@ namespace PacketDotNet
         /// <summary>
         /// The length.
         /// </summary>
-        public static readonly int Length = 12;
+        public static readonly Int32 Length = 12;
         internal ByteArraySegment header;
 
         /// <summary>
@@ -979,7 +979,7 @@ namespace PacketDotNet
         /// </summary>
         public ASExternalLink()
         {
-            byte[] b = new byte[ASExternalLink.Length];
+            Byte[] b = new Byte[ASExternalLink.Length];
             this.header = new ByteArraySegment(b);
         }
 
@@ -995,7 +995,7 @@ namespace PacketDotNet
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public ASExternalLink(byte[] packet, int offset, int length)
+        public ASExternalLink(Byte[] packet, Int32 offset, Int32 length)
         {
             this.header = new ByteArraySegment(packet, offset, length);
         }
@@ -1004,17 +1004,17 @@ namespace PacketDotNet
         /// The type of external metric.  If bit E is set, the metric
         /// specified is a Type 2 external metric.
         /// </summary>
-        public byte eBit
+        public Byte eBit
         {
             get
             {
                 var val = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
-                return (byte)((val >> 31) & 0xFF);
+                return (Byte)((val >> 31) & 0xFF);
             }
             set
             {
-                uint original = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
-                uint val = (uint)((value & 1) << 31) | original;
+                UInt32 original = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
+                UInt32 val = (UInt32)((value & 1) << 31) | original;
                 EndianBitConverter.Big.CopyBytes(val, header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
             }
         }
@@ -1022,17 +1022,17 @@ namespace PacketDotNet
         /// <summary>
         /// The Type of Service that the following fields concern.
         /// </summary>
-        public byte TOS
+        public Byte TOS
         {
             get
             {
                 var val = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
-                return (byte)((val >> 24) & 0x7F);
+                return (Byte)((val >> 24) & 0x7F);
             }
             set
             {
-                uint original = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
-                var val = (byte)((value & 0x7F) << 24) | original;
+                UInt32 original = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
+                var val = (Byte)((value & 0x7F) << 24) | original;
                 EndianBitConverter.Big.CopyBytes(val, header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
             }
         }
@@ -1041,7 +1041,7 @@ namespace PacketDotNet
         /// The cost of this route.  Interpretation depends on the external
         /// type indication (bit E above).
         /// </summary>
-        public uint Metric
+        public UInt32 Metric
         {
             get
             {
@@ -1050,7 +1050,7 @@ namespace PacketDotNet
             }
             set
             {
-                uint original = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
+                UInt32 original = EndianBitConverter.Big.ToUInt32(header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
                 var val = value & 0x00FFFFFF | original;
                 EndianBitConverter.Big.CopyBytes(val, header.Bytes, header.Offset + ASExternalLinkFields.TOSPosition);
             }
@@ -1068,7 +1068,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + ASExternalLinkFields.ForwardingAddressPosition,
                            address.Length);
@@ -1078,7 +1078,7 @@ namespace PacketDotNet
         /// <summary>
         ///  A 32-bit field attached to each external route.  This is not used by the OSPF protocol itself.
         /// </summary>
-        public uint ExternalRouteTag
+        public UInt32 ExternalRouteTag
         {
             get
             {
@@ -1093,7 +1093,7 @@ namespace PacketDotNet
         /// <summary>
         /// Bytes representation
         /// </summary>
-        public byte[] Bytes
+        public Byte[] Bytes
         {
             get
             {
@@ -1113,17 +1113,17 @@ namespace PacketDotNet
         /// </summary>
         public static readonly LSAType lsaType = LSAType.ASExternal;
 
-        const int ASExternalLinkLength = 12;
+        const Int32 ASExternalLinkLength = 12;
 
         /// <summary>
         /// Default constructor
         /// </summary>
         public ASExternalLSA()
         {
-            byte[] b = new byte[ASExternalLSAFields.MetricPosition];
+            Byte[] b = new Byte[ASExternalLSAFields.MetricPosition];
             this.header = new ByteArraySegment(b);
             this.LSType = lsaType;
-            this.Length = (ushort)this.header.Bytes.Length;
+            this.Length = (UInt16)this.header.Bytes.Length;
         }
 
         /// <summary>
@@ -1131,9 +1131,9 @@ namespace PacketDotNet
         /// </summary>
         public ASExternalLSA(List<ASExternalLink> links)
         {
-            int length = ASExternalLSAFields.MetricPosition + ASExternalLink.Length * links.Count;
-            int offset = ASExternalLSAFields.MetricPosition;
-            byte[] b = new byte[length];
+            Int32 length = ASExternalLSAFields.MetricPosition + ASExternalLink.Length * links.Count;
+            Int32 offset = ASExternalLSAFields.MetricPosition;
+            Byte[] b = new Byte[length];
 
             foreach (ASExternalLink l in links)
             {
@@ -1143,7 +1143,7 @@ namespace PacketDotNet
 
             this.header = new ByteArraySegment(b);
             this.LSType = lsaType;
-            this.Length = (ushort)this.header.Bytes.Length;
+            this.Length = (UInt16)this.header.Bytes.Length;
         }
 
         /// <summary>
@@ -1158,7 +1158,7 @@ namespace PacketDotNet
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public ASExternalLSA(byte[] packet, int offset, int length) :
+        public ASExternalLSA(Byte[] packet, Int32 offset, Int32 length) :
             base(packet, offset, length)
         {
 
@@ -1177,7 +1177,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + ASExternalLSAFields.NetworkMaskPosition,
                            address.Length);
@@ -1191,9 +1191,9 @@ namespace PacketDotNet
         {
             get
             {
-                int linkCnt = (this.Length - NetworkMaskLength - OSPFv2Fields.LSAHeaderLength) / ASExternalLinkLength;
+                Int32 linkCnt = (this.Length - NetworkMaskLength - OSPFv2Fields.LSAHeaderLength) / ASExternalLinkLength;
                 List<ASExternalLink> ret = new List<ASExternalLink>(linkCnt);
-                for(int i = 0; i < linkCnt; i++)
+                for(Int32 i = 0; i < linkCnt; i++)
                 {
                     ASExternalLink l = new ASExternalLink(header.Bytes,
                                                           header.Offset + ASExternalLSAFields.MetricPosition + i * ASExternalLink.Length,

--- a/PacketDotNet/LSAFields.cs
+++ b/PacketDotNet/LSAFields.cs
@@ -31,40 +31,40 @@ namespace PacketDotNet
     public class LSAFields
     {
         /// <summary> The length of the LSAge field in bytes</summary>
-        public readonly static int LSAgeLength = 2;
+        public readonly static Int32 LSAgeLength = 2;
         /// <summary> The length of the Options field in bytes</summary>
-        public readonly static int OptionsLength = 1;
+        public readonly static Int32 OptionsLength = 1;
         /// <summary> The length of the LSType field in bytes</summary>
-        public readonly static int LSTypeLength = 1;
+        public readonly static Int32 LSTypeLength = 1;
         /// <summary> The length of the LinkStateID field in bytes</summary>
-        public readonly static int LinkStateIDLength = 4;
+        public readonly static Int32 LinkStateIDLength = 4;
         /// <summary> The length of the AdvertisingRouterID field in bytes</summary>
-        public readonly static int AdvertisingRouterIDLength = 4;
+        public readonly static Int32 AdvertisingRouterIDLength = 4;
         /// <summary> The length of the LSSeqeunceNumber field in bytes</summary>
-        public readonly static int LSSequenceNumberLength = 4;
+        public readonly static Int32 LSSequenceNumberLength = 4;
         /// <summary> The length of the Checksum field in bytes</summary>
-        public readonly static int ChecksumLength = 2;
+        public readonly static Int32 ChecksumLength = 2;
         /// <summary> The length of the Length field in bytes</summary>
-        public readonly static int PacketLength = 2;
+        public readonly static Int32 PacketLength = 2;
 
         /// <summary> The relative postion of the LSAge field</summary>
-        public readonly static int LSAgePosition = 0;
+        public readonly static Int32 LSAgePosition = 0;
         /// <summary> The relative postion of the Option field</summary>
-        public readonly static int OptionsPosition;
+        public readonly static Int32 OptionsPosition;
         /// <summary> The relative postion of the LSType field</summary>
-        public readonly static int LSTypePosition;
+        public readonly static Int32 LSTypePosition;
         /// <summary> The relative postion of the LinkStateID field</summary>
-        public readonly static int LinkStateIDPosition;
+        public readonly static Int32 LinkStateIDPosition;
         /// <summary> The relative postion of the AdvertisingRouterID field</summary>
-        public readonly static int AdvertisingRouterIDPosition;
+        public readonly static Int32 AdvertisingRouterIDPosition;
         /// <summary> The relative postion of the LSSequenceNumber field</summary>
-        public readonly static int LSSequenceNumberPosition;
+        public readonly static Int32 LSSequenceNumberPosition;
         /// <summary> The relative postion of the Checksum field</summary>
-        public readonly static int ChecksumPosition;
+        public readonly static Int32 ChecksumPosition;
         /// <summary> The relative postion of the Length field</summary>
-        public readonly static int PacketLengthPosition;
+        public readonly static Int32 PacketLengthPosition;
         /// <summary> The relative postion of the header's end</summary>
-        public readonly static int HeaderEnd;
+        public readonly static Int32 HeaderEnd;
 
         static LSAFields()
         {
@@ -86,16 +86,16 @@ namespace PacketDotNet
     public class RouterLSAFields : LSAFields
     {
         /// <summary> The length of the RouterOptions field in bytes</summary>
-        public readonly static int RouterOptionsLength = 2;
+        public readonly static Int32 RouterOptionsLength = 2;
         /// <summary> The length of the LinkNumber field in bytes</summary>
-        public readonly static int LinkNumberLength = 2;
+        public readonly static Int32 LinkNumberLength = 2;
 
         /// <summary> The relative postion of the RouterOptions field</summary>
-        public readonly static int RouterOptionsPosition;
+        public readonly static Int32 RouterOptionsPosition;
         /// <summary> The relative postion of the LinkNumber field</summary>
-        public readonly static int LinkNumberPosition;
+        public readonly static Int32 LinkNumberPosition;
         /// <summary> The relative postion of the start of the RouterLink(s)</summary>
-        public readonly static int RouterLinksStart;
+        public readonly static Int32 RouterLinksStart;
 
         static RouterLSAFields()
         {
@@ -112,14 +112,14 @@ namespace PacketDotNet
     public class NetworkLSAFields : LSAFields
     {
         /// <summary> The length of the NetworkMask field in bytes</summary>
-        public readonly static int NetworkMaskLength = 4;
+        public readonly static Int32 NetworkMaskLength = 4;
         /// <summary> The length of the AttachedRouter field in bytes</summary>
-        public readonly static int AttachedRouterLength = 4;
+        public readonly static Int32 AttachedRouterLength = 4;
 
         /// <summary> The relative postion of the NetworkMask field</summary>
-        public readonly static int NetworkMaskPosition;
+        public readonly static Int32 NetworkMaskPosition;
         /// <summary> The relative postion of the AttachedRouter field</summary>
-        public readonly static int AttachedRouterPosition;
+        public readonly static Int32 AttachedRouterPosition;
 
         static NetworkLSAFields()
         {
@@ -135,18 +135,18 @@ namespace PacketDotNet
     public class SummaryLSAFields : LSAFields
     {
         /// <summary> The length of the NetworkMask field in bytes</summary>
-        public readonly static int NetworkMaskLength = 4;
+        public readonly static Int32 NetworkMaskLength = 4;
         /// <summary> The length of the Metric field in bytes</summary>
-        public readonly static int MetricLength = 4;
+        public readonly static Int32 MetricLength = 4;
         /// <summary> The length of the TOSMetric field in bytes</summary>
-        public readonly static int TOSMetricLength = 4;
+        public readonly static Int32 TOSMetricLength = 4;
 
         /// <summary> The relative postion of the NetworkMask field</summary>
-        public readonly static int NetworkMaskPosition;
+        public readonly static Int32 NetworkMaskPosition;
         /// <summary> The relative postion of the Metric field</summary>
-        public readonly static int MetricPosition;
+        public readonly static Int32 MetricPosition;
         /// <summary> The relative postion of the TOSMetric field</summary>
-        public readonly static int TOSMetricPosition;
+        public readonly static Int32 TOSMetricPosition;
 
         static SummaryLSAFields()
         {
@@ -163,12 +163,12 @@ namespace PacketDotNet
     public class ASExternalLSAFields : LSAFields
     {
         /// <summary> The length of the NetworkMask field in bytes</summary>
-        public readonly static int NetworkMaskLength = 4;
+        public readonly static Int32 NetworkMaskLength = 4;
 
         /// <summary> The relative postion of the NetworkMask field</summary>
-        public readonly static int NetworkMaskPosition;
+        public readonly static Int32 NetworkMaskPosition;
         /// <summary> The relative postion of the Metric field</summary>
-        public readonly static int MetricPosition;
+        public readonly static Int32 MetricPosition;
 
         static ASExternalLSAFields()
         {
@@ -184,28 +184,28 @@ namespace PacketDotNet
     public class RouterLinkFields
     {
         /// <summary> The length of the LinkID field in bytes</summary>
-        public readonly static int LinkIDLength = 4;
+        public readonly static Int32 LinkIDLength = 4;
         /// <summary> The length of the LinkData field in bytes</summary>
-        public readonly static int LinkDataLength = 4;
+        public readonly static Int32 LinkDataLength = 4;
         /// <summary> The length of the Type field in bytes</summary>
-        public readonly static int TypeLength = 1;
+        public readonly static Int32 TypeLength = 1;
         /// <summary> The length of the TOSNumber field in bytes</summary>
-        public readonly static int TOSNumberLength = 1;
+        public readonly static Int32 TOSNumberLength = 1;
         /// <summary> The length of the Metric field in bytes</summary>
-        public readonly static int MetricLength = 2;
+        public readonly static Int32 MetricLength = 2;
 
         /// <summary> The relative postion of the LinkID field</summary>
-        public readonly static int LinkIDPosition;
+        public readonly static Int32 LinkIDPosition;
         /// <summary> The relative postion of the LinkData field</summary>
-        public readonly static int LinkDataPosition;
+        public readonly static Int32 LinkDataPosition;
         /// <summary> The relative postion of the Type field</summary>
-        public readonly static int TypePosition;
+        public readonly static Int32 TypePosition;
         /// <summary> The relative postion of the TOSNumber field</summary>
-        public readonly static int TOSNumberPosition;
+        public readonly static Int32 TOSNumberPosition;
         /// <summary> The relative postion of the Metric field</summary>
-        public readonly static int MetricPosition;
+        public readonly static Int32 MetricPosition;
         /// <summary> The relative postion of the AdditionalMetrics field</summary>
-        public readonly static int AdditionalMetricsPosition;
+        public readonly static Int32 AdditionalMetricsPosition;
 
         static RouterLinkFields()
         {
@@ -225,18 +225,18 @@ namespace PacketDotNet
     public class ASExternalLinkFields
     {
         /// <summary> The length of the TOS field in bytes</summary>
-        public readonly static int TOSLength = 4;
+        public readonly static Int32 TOSLength = 4;
         /// <summary> The length of the ForwardingAddress field in bytes</summary>
-        public readonly static int ForwardingAddressLength = 4;
+        public readonly static Int32 ForwardingAddressLength = 4;
         /// <summary> The length of the ExternalRouteTag field in bytes</summary>
-        public readonly static int ExternalRouteTagLength = 4;
+        public readonly static Int32 ExternalRouteTagLength = 4;
 
         /// <summary> The relative postion of the TOSPosition field</summary>
-        public readonly static int TOSPosition;
+        public readonly static Int32 TOSPosition;
         /// <summary> The relative postion of the ForwardingAddress field</summary>
-        public readonly static int ForwardingAddressPosition;
+        public readonly static Int32 ForwardingAddressPosition;
         /// <summary> The relative postion of the ExternalRouteTag field</summary>
-        public readonly static int ExternalRouteTagPosition;
+        public readonly static Int32 ExternalRouteTagPosition;
 
         static ASExternalLinkFields()
         {
@@ -253,18 +253,18 @@ namespace PacketDotNet
     public class LinkStateRequestFields
     {
         /// <summary> The length of the LSType field in bytes</summary>
-        public readonly static int LSTypeLength = 4;
+        public readonly static Int32 LSTypeLength = 4;
         /// <summary> The length of the LinkStateID field in bytes</summary>
-        public readonly static int LinkStateIdLength = 4;
+        public readonly static Int32 LinkStateIdLength = 4;
         /// <summary> The length of the AdvertisingRouter field in bytes</summary>
-        public readonly static int AdvertisingRouterLength = 4;
+        public readonly static Int32 AdvertisingRouterLength = 4;
 
         /// <summary> The relative postion of the LSType field</summary>
-        public readonly static int LSTypePosition;
+        public readonly static Int32 LSTypePosition;
         /// <summary> The relative postion of the LinkStateID field</summary>
-        public readonly static int LinkStateIdPosition;
+        public readonly static Int32 LinkStateIdPosition;
         /// <summary> The relative postion of the AdvertisingRouter field</summary>
-        public readonly static int AdvertisingRouterPosition;
+        public readonly static Int32 AdvertisingRouterPosition;
 
         static LinkStateRequestFields()
         {

--- a/PacketDotNet/LinuxSLLFields.cs
+++ b/PacketDotNet/LinuxSLLFields.cs
@@ -30,58 +30,58 @@ namespace PacketDotNet
         /// <summary>
         /// Length of the packet type field
         /// </summary>
-        public readonly static int PacketTypeLength = 2;
+        public readonly static Int32 PacketTypeLength = 2;
 
         /// <summary>
         /// Link layer address type
         /// </summary>
-        public readonly static int LinkLayerAddressTypeLength = 2;
+        public readonly static Int32 LinkLayerAddressTypeLength = 2;
 
         /// <summary>
         /// Link layer address length
         /// </summary>
-        public readonly static int LinkLayerAddressLengthLength = 2;
+        public readonly static Int32 LinkLayerAddressLengthLength = 2;
 
         /// <summary>
         /// The link layer address field length
         /// NOTE: the actual link layer address MAY be shorter than this
         /// </summary>
-        public readonly static int LinkLayerAddressMaximumLength = 8;
+        public readonly static Int32 LinkLayerAddressMaximumLength = 8;
 
         /// <summary>
         /// Number of bytes in a SLL header
         /// </summary>
-        public readonly static int SLLHeaderLength = 16;
+        public readonly static Int32 SLLHeaderLength = 16;
 
         /// <summary>
         /// Length of the ethernet protocol field
         /// </summary>
-        public readonly static int EthernetProtocolTypeLength = 2;
+        public readonly static Int32 EthernetProtocolTypeLength = 2;
 
         /// <summary>
         /// Position of the packet type field
         /// </summary>
-        public readonly static int PacketTypePosition = 0;
+        public readonly static Int32 PacketTypePosition = 0;
 
         /// <summary>
         /// Position of the link layer address type field
         /// </summary>
-        public readonly static int LinkLayerAddressTypePosition;
+        public readonly static Int32 LinkLayerAddressTypePosition;
 
         /// <summary>
         /// Positino of the link layer address length field
         /// </summary>
-        public readonly static int LinkLayerAddressLengthPosition;
+        public readonly static Int32 LinkLayerAddressLengthPosition;
 
         /// <summary>
         /// Position of the link layer address field
         /// </summary>
-        public readonly static int LinkLayerAddressPosition;
+        public readonly static Int32 LinkLayerAddressPosition;
 
         /// <summary>
         /// Position of the ethernet protocol type field
         /// </summary>
-        public readonly static int EthernetProtocolTypePosition;
+        public readonly static Int32 EthernetProtocolTypePosition;
 
         static LinuxSLLFields()
         {

--- a/PacketDotNet/LinuxSLLPacket.cs
+++ b/PacketDotNet/LinuxSLLPacket.cs
@@ -56,7 +56,7 @@ namespace PacketDotNet
         /// <value>
         /// The
         /// </value>
-        public int LinkLayerAddressType
+        public Int32 LinkLayerAddressType
         {
             get
             {
@@ -76,7 +76,7 @@ namespace PacketDotNet
         /// <value>
         /// Number of bytes in the link layer address of the sender of the packet
         /// </value>
-        public int LinkLayerAddressLength
+        public Int32 LinkLayerAddressLength
         {
             get
             {
@@ -102,7 +102,7 @@ namespace PacketDotNet
         /// <value>
         /// Link layer header bytes, maximum of 8 bytes
         /// </value>
-        public byte[] LinkLayerAddress
+        public Byte[] LinkLayerAddress
         {
             get
             {
@@ -163,11 +163,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString (StringOutputType outputFormat)
+        public override String ToString (StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -191,8 +191,8 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
-                properties.Add("type", Type.ToString() + " (" + ((int)Type).ToString() + ")");
+                Dictionary<String,String> properties = new Dictionary<String,String>();
+                properties.Add("type", Type.ToString() + " (" + ((Int32)Type).ToString() + ")");
                 properties.Add("link layer address type", LinkLayerAddressType.ToString());
                 properties.Add("link layer address length", LinkLayerAddressLength.ToString());
                 properties.Add("source", BitConverter.ToString(LinkLayerAddress));
@@ -200,7 +200,7 @@ namespace PacketDotNet
 
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("LCC:  ******* LinuxSLL - \"Linux Cooked Capture\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/MiscUtil/Conversion/BigEndianBitConverter.cs
+++ b/PacketDotNet/MiscUtil/Conversion/BigEndianBitConverter.cs
@@ -1,4 +1,6 @@
 
+using System;
+
 namespace MiscUtil.Conversion
 {
     /// <summary>
@@ -16,7 +18,7 @@ namespace MiscUtil.Conversion
         /// most significant byte is on the right end of a word.
         /// </remarks>
         /// <returns>true if this converter is little-endian, false otherwise.</returns>
-        public sealed override bool IsLittleEndian()
+        public sealed override Boolean IsLittleEndian()
         {
             return false;
         }
@@ -36,12 +38,12 @@ namespace MiscUtil.Conversion
         /// <param name="bytes">The number of bytes to copy</param>
         /// <param name="buffer">The buffer to copy the bytes into</param>
         /// <param name="index">The index to start at</param>
-        protected override void CopyBytesImpl(long value, int bytes, byte[] buffer, int index)
+        protected override void CopyBytesImpl(Int64 value, Int32 bytes, Byte[] buffer, Int32 index)
         {
-            int endOffset = index+bytes-1;
-            for (int i=0; i < bytes; i++)
+            Int32 endOffset = index+bytes-1;
+            for (Int32 i=0; i < bytes; i++)
             {
-                buffer[endOffset-i] = unchecked((byte)(value&0xff));
+                buffer[endOffset-i] = unchecked((Byte)(value&0xff));
                 value = value >> 8;
             }
         }
@@ -54,10 +56,10 @@ namespace MiscUtil.Conversion
         /// <param name="startIndex">The first index to use</param>
         /// <param name="bytesToConvert">The number of bytes to use</param>
         /// <returns>The value built from the given bytes</returns>
-        protected override long FromBytes(byte[] buffer, int startIndex, int bytesToConvert)
+        protected override Int64 FromBytes(Byte[] buffer, Int32 startIndex, Int32 bytesToConvert)
         {
-            long ret = 0;
-            for (int i=0; i < bytesToConvert; i++)
+            Int64 ret = 0;
+            for (Int32 i=0; i < bytesToConvert; i++)
             {
                 ret = unchecked((ret << 8) | buffer[startIndex+i]);
             }

--- a/PacketDotNet/MiscUtil/Conversion/DoubleConverter.cs
+++ b/PacketDotNet/MiscUtil/Conversion/DoubleConverter.cs
@@ -16,20 +16,20 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="d">The double to convert.</param>
         /// <returns>A string representation of the double's exact decimal value.</returns>
-        public static string ToExactString (double d)
+        public static String ToExactString (Double d)
         {
-            if (double.IsPositiveInfinity(d))
+            if (Double.IsPositiveInfinity(d))
                 return "+Infinity";
-            if (double.IsNegativeInfinity(d))
+            if (Double.IsNegativeInfinity(d))
                 return "-Infinity";
-            if (double.IsNaN(d))
+            if (Double.IsNaN(d))
                 return "NaN";
 
             // Translate the double into sign, exponent and mantissa.
-            long bits = BitConverter.DoubleToInt64Bits(d);
-            bool negative = (bits < 0);
-            int exponent = (int) ((bits >> 52) & 0x7ffL);
-            long mantissa = bits & 0xfffffffffffffL;
+            Int64 bits = BitConverter.DoubleToInt64Bits(d);
+            Boolean negative = (bits < 0);
+            Int32 exponent = (Int32) ((bits >> 52) & 0x7ffL);
+            Int64 mantissa = bits & 0xfffffffffffffL;
 
             // Subnormal numbers; exponent is effectively one higher,
             // but there's no extra normalisation bit in the mantissa
@@ -69,14 +69,14 @@ namespace MiscUtil.Conversion
             // by 5 and dividing by 10.
             if (exponent < 0)
             {
-                for (int i=0; i < -exponent; i++)
+                for (Int32 i=0; i < -exponent; i++)
                     ad.MultiplyBy(5);
                 ad.Shift(-exponent);
             }
                 // Otherwise, we need to repeatedly multiply by 2
             else
             {
-                for (int i=0; i < exponent; i++)
+                for (Int32 i=0; i < exponent; i++)
                     ad.MultiplyBy(2);
             }
 
@@ -93,22 +93,22 @@ namespace MiscUtil.Conversion
         class ArbitraryDecimal
         {
             /// <summary>Digits in the decimal expansion, one byte per digit</summary>
-            byte[] digits;
+            Byte[] digits;
             /// <summary>
             /// How many digits are *after* the decimal point
             /// </summary>
-            int decimalPoint=0;
+            Int32 decimalPoint=0;
 
             /// <summary>
             /// Constructs an arbitrary decimal expansion from the given long.
             /// The long must not be negative.
             /// </summary>
-            internal ArbitraryDecimal (long x)
+            internal ArbitraryDecimal (Int64 x)
             {
-                string tmp = x.ToString(CultureInfo.InvariantCulture);
-                digits = new byte[tmp.Length];
-                for (int i=0; i < tmp.Length; i++)
-                    digits[i] = (byte) (tmp[i]-'0');
+                String tmp = x.ToString(CultureInfo.InvariantCulture);
+                digits = new Byte[tmp.Length];
+                for (Int32 i=0; i < tmp.Length; i++)
+                    digits[i] = (Byte) (tmp[i]-'0');
                 Normalize();
             }
 
@@ -116,14 +116,14 @@ namespace MiscUtil.Conversion
             /// Multiplies the current expansion by the given amount, which should
             /// only be 2 or 5.
             /// </summary>
-            internal void MultiplyBy(int amount)
+            internal void MultiplyBy(Int32 amount)
             {
-                byte[] result = new byte[digits.Length+1];
-                for (int i=digits.Length-1; i >= 0; i--)
+                Byte[] result = new Byte[digits.Length+1];
+                for (Int32 i=digits.Length-1; i >= 0; i--)
                 {
-                    int resultDigit = digits[i]*amount+result[i+1];
-                    result[i]=(byte)(resultDigit/10);
-                    result[i+1]=(byte)(resultDigit%10);
+                    Int32 resultDigit = digits[i]*amount+result[i+1];
+                    result[i]=(Byte)(resultDigit/10);
+                    result[i+1]=(Byte)(resultDigit%10);
                 }
                 if (result[0] != 0)
                 {
@@ -142,7 +142,7 @@ namespace MiscUtil.Conversion
             /// decimal place) and a positive value makes the decimal
             /// expansion smaller.
             /// </summary>
-            internal void Shift (int amount)
+            internal void Shift (Int32 amount)
             {
                 decimalPoint += amount;
             }
@@ -152,11 +152,11 @@ namespace MiscUtil.Conversion
             /// </summary>
             internal void Normalize()
             {
-                int first;
+                Int32 first;
                 for (first=0; first < digits.Length; first++)
                     if (digits[first]!=0)
                         break;
-                int last;
+                Int32 last;
                 for (last=digits.Length-1; last >= 0; last--)
                     if (digits[last]!=0)
                         break;
@@ -164,8 +164,8 @@ namespace MiscUtil.Conversion
                 if (first==0 && last==digits.Length-1)
                     return;
 
-                byte[] tmp = new byte[last-first+1];
-                for (int i=0; i < tmp.Length; i++)
+                Byte[] tmp = new Byte[last-first+1];
+                for (Int32 i=0; i < tmp.Length; i++)
                     tmp[i]=digits[i+first];
 
                 decimalPoint -= digits.Length-(last+1);
@@ -177,40 +177,40 @@ namespace MiscUtil.Conversion
             /// </summary>
             public override String ToString()
             {
-                char[] digitString = new char[digits.Length];
-                for (int i=0; i < digits.Length; i++)
-                    digitString[i] = (char)(digits[i]+'0');
+                Char[] digitString = new Char[digits.Length];
+                for (Int32 i=0; i < digits.Length; i++)
+                    digitString[i] = (Char)(digits[i]+'0');
 
                 // Simplest case - nothing after the decimal point,
                 // and last real digit is non-zero, eg value=35
                 if (decimalPoint==0)
                 {
-                    return new string (digitString);
+                    return new String (digitString);
                 }
 
                 // Fairly simple case - nothing after the decimal
                 // point, but some 0s to add, eg value=350
                 if (decimalPoint < 0)
                 {
-                    return new string (digitString)+
-                        new string ('0', -decimalPoint);
+                    return new String (digitString)+
+                        new String ('0', -decimalPoint);
                 }
 
                 // Nothing before the decimal point, eg 0.035
                 if (decimalPoint >= digitString.Length)
                 {
                     return "0."+
-                        new string ('0',(decimalPoint-digitString.Length))+
-                        new string (digitString);
+                        new String ('0',(decimalPoint-digitString.Length))+
+                        new String (digitString);
                 }
 
                 // Most complicated case - part of the string comes
                 // before the decimal point, part comes after it,
                 // eg 3.5
-                return new string (digitString, 0,
+                return new String (digitString, 0,
                     digitString.Length-decimalPoint)+
                     "."+
-                    new string (digitString,
+                    new String (digitString,
                     digitString.Length-decimalPoint,
                     decimalPoint);
             }

--- a/PacketDotNet/MiscUtil/Conversion/EndianBitConverter.cs
+++ b/PacketDotNet/MiscUtil/Conversion/EndianBitConverter.cs
@@ -18,7 +18,7 @@ namespace MiscUtil.Conversion
         /// most significant byte is on the right end of a word.
         /// </remarks>
         /// <returns>true if this converter is little-endian, false otherwise.</returns>
-        public abstract bool IsLittleEndian();
+        public abstract Boolean IsLittleEndian();
 
         /// <summary>
         /// Indicates the byte order ("endianess") in which data is converted using this class.
@@ -56,7 +56,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert. </param>
         /// <returns>A 64-bit signed integer whose value is equivalent to value.</returns>
-        public long DoubleToInt64Bits(double value)
+        public Int64 DoubleToInt64Bits(Double value)
         {
             return BitConverter.DoubleToInt64Bits(value);
         }
@@ -68,7 +68,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert. </param>
         /// <returns>A double-precision floating point number whose value is equivalent to value.</returns>
-        public double Int64BitsToDouble (long value)
+        public Double Int64BitsToDouble (Int64 value)
         {
             return BitConverter.Int64BitsToDouble(value);
         }
@@ -80,7 +80,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert. </param>
         /// <returns>A 32-bit signed integer whose value is equivalent to value.</returns>
-        public int SingleToInt32Bits(float value)
+        public Int32 SingleToInt32Bits(Single value)
         {
             return new Int32SingleUnion(value).AsInt32;
         }
@@ -92,7 +92,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert. </param>
         /// <returns>A single-precision floating point number whose value is equivalent to value.</returns>
-        public float Int32BitsToSingle (int value)
+        public Single Int32BitsToSingle (Int32 value)
         {
             return new Int32SingleUnion(value).AsSingle;
         }
@@ -105,7 +105,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>true if the byte at startIndex in value is nonzero; otherwise, false.</returns>
-        public bool ToBoolean (byte[] value, int startIndex)
+        public Boolean ToBoolean (Byte[] value, Int32 startIndex)
         {
             CheckByteArgument(value, startIndex, 1);
             return BitConverter.ToBoolean(value, startIndex);
@@ -117,9 +117,9 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A character formed by two bytes beginning at startIndex.</returns>
-        public char ToChar (byte[] value, int startIndex)
+        public Char ToChar (Byte[] value, Int32 startIndex)
         {
-            return unchecked((char) (CheckedFromBytes(value, startIndex, 2)));
+            return unchecked((Char) (CheckedFromBytes(value, startIndex, 2)));
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A double precision floating point number formed by eight bytes beginning at startIndex.</returns>
-        public double ToDouble (byte[] value, int startIndex)
+        public Double ToDouble (Byte[] value, Int32 startIndex)
         {
             return Int64BitsToDouble(ToInt64(value, startIndex));
         }
@@ -141,7 +141,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A single precision floating point number formed by four bytes beginning at startIndex.</returns>
-        public float ToSingle (byte[] value, int startIndex)
+        public Single ToSingle (Byte[] value, Int32 startIndex)
         {
             return Int32BitsToSingle(ToInt32(value, startIndex));
         }
@@ -152,9 +152,9 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 16-bit signed integer formed by two bytes beginning at startIndex.</returns>
-        public short ToInt16 (byte[] value, int startIndex)
+        public Int16 ToInt16 (Byte[] value, Int32 startIndex)
         {
-            return unchecked((short) (CheckedFromBytes(value, startIndex, 2)));
+            return unchecked((Int16) (CheckedFromBytes(value, startIndex, 2)));
         }
 
         /// <summary>
@@ -163,9 +163,9 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 32-bit signed integer formed by four bytes beginning at startIndex.</returns>
-        public int ToInt32 (byte[] value, int startIndex)
+        public Int32 ToInt32 (Byte[] value, Int32 startIndex)
         {
-            return unchecked((int) (CheckedFromBytes(value, startIndex, 4)));
+            return unchecked((Int32) (CheckedFromBytes(value, startIndex, 4)));
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 64-bit signed integer formed by eight bytes beginning at startIndex.</returns>
-        public long ToInt64 (byte[] value, int startIndex)
+        public Int64 ToInt64 (Byte[] value, Int32 startIndex)
         {
             return CheckedFromBytes(value, startIndex, 8);
         }
@@ -185,9 +185,9 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 16-bit unsigned integer formed by two bytes beginning at startIndex.</returns>
-        public ushort ToUInt16 (byte[] value, int startIndex)
+        public UInt16 ToUInt16 (Byte[] value, Int32 startIndex)
         {
-            return unchecked((ushort) (CheckedFromBytes(value, startIndex, 2)));
+            return unchecked((UInt16) (CheckedFromBytes(value, startIndex, 2)));
         }
 
         /// <summary>
@@ -196,9 +196,9 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 32-bit unsigned integer formed by four bytes beginning at startIndex.</returns>
-        public uint ToUInt32 (byte[] value, int startIndex)
+        public UInt32 ToUInt32 (Byte[] value, Int32 startIndex)
         {
-            return unchecked((uint) (CheckedFromBytes(value, startIndex, 4)));
+            return unchecked((UInt32) (CheckedFromBytes(value, startIndex, 4)));
         }
 
         /// <summary>
@@ -207,9 +207,9 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A 64-bit unsigned integer formed by eight bytes beginning at startIndex.</returns>
-        public ulong ToUInt64 (byte[] value, int startIndex)
+        public UInt64 ToUInt64 (Byte[] value, Int32 startIndex)
         {
-            return unchecked((ulong) (CheckedFromBytes(value, startIndex, 8)));
+            return unchecked((UInt64) (CheckedFromBytes(value, startIndex, 8)));
         }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace MiscUtil.Conversion
         /// <exception cref="ArgumentOutOfRangeException">
         /// startIndex is less than zero or greater than the length of value minus bytesRequired.
         /// </exception>
-        static void CheckByteArgument(byte[] value, int startIndex, int bytesRequired)
+        static void CheckByteArgument(Byte[] value, Int32 startIndex, Int32 bytesRequired)
         {
             if (value==null)
             {
@@ -242,7 +242,7 @@ namespace MiscUtil.Conversion
         /// <param name="startIndex">The index of the first byte to convert</param>
         /// <param name="bytesToConvert">The number of bytes to convert</param>
         /// <returns></returns>
-        long CheckedFromBytes(byte[] value, int startIndex, int bytesToConvert)
+        Int64 CheckedFromBytes(Byte[] value, Int32 startIndex, Int32 bytesToConvert)
         {
             CheckByteArgument(value, startIndex, bytesToConvert);
             return FromBytes(value, startIndex, bytesToConvert);
@@ -257,7 +257,7 @@ namespace MiscUtil.Conversion
         /// <param name="startIndex">The index of the first byte to convert</param>
         /// <param name="bytesToConvert">The number of bytes to use in the conversion</param>
         /// <returns>The converted number</returns>
-        protected abstract long FromBytes(byte[] value, int startIndex, int bytesToConvert);
+        protected abstract Int64 FromBytes(Byte[] value, Int32 startIndex, Int32 bytesToConvert);
         #endregion
 
         #region ToString conversions
@@ -270,7 +270,7 @@ namespace MiscUtil.Conversion
         /// A String of hexadecimal pairs separated by hyphens, where each pair
         /// represents the corresponding element in value; for example, "7F-2C-4A".
         /// </returns>
-        public static string ToString(byte[] value)
+        public static String ToString(Byte[] value)
         {
             return BitConverter.ToString(value);
         }
@@ -285,7 +285,7 @@ namespace MiscUtil.Conversion
         /// A String of hexadecimal pairs separated by hyphens, where each pair
         /// represents the corresponding element in value; for example, "7F-2C-4A".
         /// </returns>
-        public static string ToString(byte[] value, int startIndex)
+        public static String ToString(Byte[] value, Int32 startIndex)
         {
             return BitConverter.ToString(value, startIndex);
         }
@@ -301,7 +301,7 @@ namespace MiscUtil.Conversion
         /// A String of hexadecimal pairs separated by hyphens, where each pair
         /// represents the corresponding element in value; for example, "7F-2C-4A".
         /// </returns>
-        public static string ToString(byte[] value, int startIndex, int length)
+        public static String ToString(Byte[] value, Int32 startIndex, Int32 length)
         {
             return BitConverter.ToString(value, startIndex, length);
         }
@@ -315,13 +315,13 @@ namespace MiscUtil.Conversion
         /// <param name="value">An array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
         /// <returns>A decimal  formed by sixteen bytes beginning at startIndex.</returns>
-        public decimal ToDecimal (byte[] value, int startIndex)
+        public Decimal ToDecimal (Byte[] value, Int32 startIndex)
         {
             // HACK: This always assumes four parts, each in their own endianness,
             // starting with the first part at the start of the byte array.
             // On the other hand, there's no real format specified...
-            int[] parts = new int[4];
-            for (int i=0; i < 4; i++)
+            Int32[] parts = new Int32[4];
+            for (Int32 i=0; i < 4; i++)
             {
                 parts[i] = ToInt32(value, startIndex+i*4);
             }
@@ -333,11 +333,11 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 16.</returns>
-        public byte[] GetBytes(decimal value)
+        public Byte[] GetBytes(Decimal value)
         {
-            byte[] bytes = new byte[16];
-            int[] parts = decimal.GetBits(value);
-            for (int i=0; i < 4; i++)
+            Byte[] bytes = new Byte[16];
+            Int32[] parts = Decimal.GetBits(value);
+            for (Int32 i=0; i < 4; i++)
             {
                 CopyBytesImpl(parts[i], 4, bytes, i*4);
             }
@@ -351,10 +351,10 @@ namespace MiscUtil.Conversion
         /// <param name="value">A character to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(decimal value, byte[] buffer, int index)
+        public void CopyBytes(Decimal value, Byte[] buffer, Int32 index)
         {
-            int[] parts = decimal.GetBits(value);
-            for (int i=0; i < 4; i++)
+            Int32[] parts = Decimal.GetBits(value);
+            for (Int32 i=0; i < 4; i++)
             {
                 CopyBytesImpl(parts[i], 4, buffer, i*4+index);
             }
@@ -369,9 +369,9 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The value to get bytes for</param>
         /// <param name="bytes">The number of significant bytes to return</param>
-        byte[] GetBytes(long value, int bytes)
+        Byte[] GetBytes(Int64 value, Int32 bytes)
         {
-            byte[] buffer = new byte[bytes];
+            Byte[] buffer = new Byte[bytes];
             CopyBytes(value, bytes, buffer, 0);
             return buffer;
         }
@@ -381,7 +381,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">A Boolean value.</param>
         /// <returns>An array of bytes with length 1.</returns>
-        public byte[] GetBytes(bool value)
+        public Byte[] GetBytes(Boolean value)
         {
             return BitConverter.GetBytes(value);
         }
@@ -391,7 +391,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">A character to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
-        public byte[] GetBytes(char value)
+        public Byte[] GetBytes(Char value)
         {
             return GetBytes(value, 2);
         }
@@ -401,7 +401,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
-        public byte[] GetBytes(double value)
+        public Byte[] GetBytes(Double value)
         {
             return GetBytes(DoubleToInt64Bits(value), 8);
         }
@@ -411,7 +411,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
-        public byte[] GetBytes(short value)
+        public Byte[] GetBytes(Int16 value)
         {
             return GetBytes(value, 2);
         }
@@ -421,7 +421,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
-        public byte[] GetBytes(int value)
+        public Byte[] GetBytes(Int32 value)
         {
             return GetBytes(value, 4);
         }
@@ -431,7 +431,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
-        public byte[] GetBytes(long value)
+        public Byte[] GetBytes(Int64 value)
         {
             return GetBytes(value, 8);
         }
@@ -441,7 +441,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
-        public byte[] GetBytes(float value)
+        public Byte[] GetBytes(Single value)
         {
             return GetBytes(SingleToInt32Bits(value), 4);
         }
@@ -451,7 +451,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 2.</returns>
-        public byte[] GetBytes(ushort value)
+        public Byte[] GetBytes(UInt16 value)
         {
             return GetBytes(value, 2);
         }
@@ -461,7 +461,7 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 4.</returns>
-        public byte[] GetBytes(uint value)
+        public Byte[] GetBytes(UInt32 value)
         {
             return GetBytes(value, 4);
         }
@@ -471,9 +471,9 @@ namespace MiscUtil.Conversion
         /// </summary>
         /// <param name="value">The number to convert.</param>
         /// <returns>An array of bytes with length 8.</returns>
-        public byte[] GetBytes(ulong value)
+        public Byte[] GetBytes(UInt64 value)
         {
-            return GetBytes(unchecked((long)value), 8);
+            return GetBytes(unchecked((Int64)value), 8);
         }
 
         #endregion
@@ -489,7 +489,7 @@ namespace MiscUtil.Conversion
         /// <param name="bytes">The number of significant bytes to copy</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        void CopyBytes(long value, int bytes, byte[] buffer, int index)
+        void CopyBytes(Int64 value, Int32 bytes, Byte[] buffer, Int32 index)
         {
             if (buffer==null)
             {
@@ -513,7 +513,7 @@ namespace MiscUtil.Conversion
         /// <param name="bytes">The number of significant bytes to copy</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        protected abstract void CopyBytesImpl(long value, int bytes, byte[] buffer, int index);
+        protected abstract void CopyBytesImpl(Int64 value, Int32 bytes, Byte[] buffer, Int32 index);
 
         /// <summary>
         /// Copies the specified Boolean value into the specified byte array,
@@ -522,7 +522,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">A Boolean value.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(bool value, byte[] buffer, int index)
+        public void CopyBytes(Boolean value, Byte[] buffer, Int32 index)
         {
             CopyBytes(value ? 1 : 0, 1, buffer, index);
         }
@@ -534,7 +534,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">A character to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(char value, byte[] buffer, int index)
+        public void CopyBytes(Char value, Byte[] buffer, Int32 index)
         {
             CopyBytes(value, 2, buffer, index);
         }
@@ -546,7 +546,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(double value, byte[] buffer, int index)
+        public void CopyBytes(Double value, Byte[] buffer, Int32 index)
         {
             CopyBytes(DoubleToInt64Bits(value), 8, buffer, index);
         }
@@ -558,7 +558,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(short value, byte[] buffer, int index)
+        public void CopyBytes(Int16 value, Byte[] buffer, Int32 index)
         {
             CopyBytes(value, 2, buffer, index);
         }
@@ -570,7 +570,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(int value, byte[] buffer, int index)
+        public void CopyBytes(Int32 value, Byte[] buffer, Int32 index)
         {
             CopyBytes(value, 4, buffer, index);
         }
@@ -582,7 +582,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(long value, byte[] buffer, int index)
+        public void CopyBytes(Int64 value, Byte[] buffer, Int32 index)
         {
             CopyBytes(value, 8, buffer, index);
         }
@@ -594,7 +594,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(float value, byte[] buffer, int index)
+        public void CopyBytes(Single value, Byte[] buffer, Int32 index)
         {
             CopyBytes(SingleToInt32Bits(value), 4, buffer, index);
         }
@@ -606,7 +606,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(ushort value, byte[] buffer, int index)
+        public void CopyBytes(UInt16 value, Byte[] buffer, Int32 index)
         {
             CopyBytes(value, 2, buffer, index);
         }
@@ -618,7 +618,7 @@ namespace MiscUtil.Conversion
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(uint value, byte[] buffer, int index)
+        public void CopyBytes(UInt32 value, Byte[] buffer, Int32 index)
         {
             CopyBytes(value, 4, buffer, index);
         }
@@ -630,9 +630,9 @@ namespace MiscUtil.Conversion
         /// <param name="value">The number to convert.</param>
         /// <param name="buffer">The byte array to copy the bytes into</param>
         /// <param name="index">The first index into the array to copy the bytes into</param>
-        public void CopyBytes(ulong value, byte[] buffer, int index)
+        public void CopyBytes(UInt64 value, Byte[] buffer, Int32 index)
         {
-            CopyBytes(unchecked((long)value), 8, buffer, index);
+            CopyBytes(unchecked((Int64)value), 8, buffer, index);
         }
 
         #endregion
@@ -648,18 +648,18 @@ namespace MiscUtil.Conversion
             /// Int32 version of the value.
             /// </summary>
             [FieldOffset(0)]
-            int i;
+            Int32 i;
             /// <summary>
             /// Single version of the value.
             /// </summary>
             [FieldOffset(0)]
-            float f;
+            Single f;
 
             /// <summary>
             /// Creates an instance representing the given integer.
             /// </summary>
             /// <param name="i">The integer value of the new instance.</param>
-            internal Int32SingleUnion(int i)
+            internal Int32SingleUnion(Int32 i)
             {
                 this.f = 0; // Just to keep the compiler happy
                 this.i = i;
@@ -669,7 +669,7 @@ namespace MiscUtil.Conversion
             /// Creates an instance representing the given floating point number.
             /// </summary>
             /// <param name="f">The floating point value of the new instance.</param>
-            internal Int32SingleUnion(float f)
+            internal Int32SingleUnion(Single f)
             {
                 this.i = 0; // Just to keep the compiler happy
                 this.f = f;
@@ -678,7 +678,7 @@ namespace MiscUtil.Conversion
             /// <summary>
             /// Returns the value of the instance as an integer.
             /// </summary>
-            internal int AsInt32
+            internal Int32 AsInt32
             {
                 get { return i; }
             }
@@ -686,7 +686,7 @@ namespace MiscUtil.Conversion
             /// <summary>
             /// Returns the value of the instance as a floating point number.
             /// </summary>
-            internal float AsSingle
+            internal Single AsSingle
             {
                 get { return f; }
             }

--- a/PacketDotNet/MiscUtil/Conversion/LittleEndianBitConverter.cs
+++ b/PacketDotNet/MiscUtil/Conversion/LittleEndianBitConverter.cs
@@ -1,4 +1,6 @@
 
+using System;
+
 namespace MiscUtil.Conversion
 {
     /// <summary>
@@ -16,7 +18,7 @@ namespace MiscUtil.Conversion
         /// most significant byte is on the right end of a word.
         /// </remarks>
         /// <returns>true if this converter is little-endian, false otherwise.</returns>
-        public sealed override bool IsLittleEndian()
+        public sealed override Boolean IsLittleEndian()
         {
             return true;
         }
@@ -36,11 +38,11 @@ namespace MiscUtil.Conversion
         /// <param name="bytes">The number of bytes to copy</param>
         /// <param name="buffer">The buffer to copy the bytes into</param>
         /// <param name="index">The index to start at</param>
-        protected override void CopyBytesImpl(long value, int bytes, byte[] buffer, int index)
+        protected override void CopyBytesImpl(Int64 value, Int32 bytes, Byte[] buffer, Int32 index)
         {
-            for (int i=0; i < bytes; i++)
+            for (Int32 i=0; i < bytes; i++)
             {
-                buffer[i+index] = unchecked((byte)(value&0xff));
+                buffer[i+index] = unchecked((Byte)(value&0xff));
                 value = value >> 8;
             }
         }
@@ -53,10 +55,10 @@ namespace MiscUtil.Conversion
         /// <param name="startIndex">The first index to use</param>
         /// <param name="bytesToConvert">The number of bytes to use</param>
         /// <returns>The value built from the given bytes</returns>
-        protected override long FromBytes(byte[] buffer, int startIndex, int bytesToConvert)
+        protected override Int64 FromBytes(Byte[] buffer, Int32 startIndex, Int32 bytesToConvert)
         {
-            long ret = 0;
-            for (int i=0; i < bytesToConvert; i++)
+            Int64 ret = 0;
+            for (Int32 i=0; i < bytesToConvert; i++)
             {
                 ret = unchecked((ret << 8) | buffer[startIndex+bytesToConvert-1-i]);
             }

--- a/PacketDotNet/MiscUtil/Conversion/StringConverter.cs
+++ b/PacketDotNet/MiscUtil/Conversion/StringConverter.cs
@@ -27,7 +27,7 @@ namespace MiscUtil.Conversion
     /// </summary>
     public class StringConverter
     {
-		static int[] e2aTable = new int[256]
+		static Int32[] e2aTable = new Int32[256]
         {
         				 0, 1, 2, 3,156, 9,134,127,151,141,142, 11, 12, 13, 14, 15,
         				16, 17, 18, 19,157,133, 8,135, 24, 25,146,143, 28, 29, 30, 31,
@@ -55,12 +55,12 @@ namespace MiscUtil.Conversion
 		/// <param name="offset">offset</param>
 		/// <param name="length">length</param>
 		/// <returns></returns>
-		public static string EbcdicToAscii(byte[] data, int offset, int length)
+		public static String EbcdicToAscii(Byte[] data, Int32 offset, Int32 length)
         {
             var stringBuilder = new StringBuilder();
             try
             {
-                for (int i = offset; i < data.Length && i - offset < length; i++)
+                for (Int32 i = offset; i < data.Length && i - offset < length; i++)
                 {
                     //0x00 Means blank, packet do have lots blank,ignore it
                     if (data[i] == 0x00)

--- a/PacketDotNet/MiscUtil/IO/EndianBinaryReader.cs
+++ b/PacketDotNet/MiscUtil/IO/EndianBinaryReader.cs
@@ -16,7 +16,7 @@ namespace MiscUtil.IO
         /// <summary>
         /// Whether or not this reader has been disposed yet.
         /// </summary>
-        bool disposed=false;
+        Boolean disposed=false;
         /// <summary>
         /// Decoder to use for string conversions.
         /// </summary>
@@ -24,15 +24,15 @@ namespace MiscUtil.IO
         /// <summary>
         /// Buffer used for temporary storage before conversion into primitives
         /// </summary>
-        byte[] buffer = new byte[16];
+        Byte[] buffer = new Byte[16];
         /// <summary>
         /// Buffer used for temporary storage when reading a single character
         /// </summary>
-        char[] charBuffer = new char[1];
+        Char[] charBuffer = new Char[1];
         /// <summary>
         /// Minimum number of bytes used to encode a character
         /// </summary>
-        int minBytesPerChar;
+        Int32 minBytesPerChar;
         #endregion
 
         #region Constructors
@@ -128,7 +128,7 @@ namespace MiscUtil.IO
         /// </summary>
         /// <param name="offset">Offset to seek to.</param>
         /// <param name="origin">Origin of seek operation.</param>
-        public void Seek (int offset, SeekOrigin origin)
+        public void Seek (Int32 offset, SeekOrigin origin)
         {
             CheckDisposed();
             stream.Seek (offset, origin);
@@ -138,7 +138,7 @@ namespace MiscUtil.IO
         /// Reads a single byte from the stream.
         /// </summary>
         /// <returns>The byte read</returns>
-        public byte ReadByte()
+        public Byte ReadByte()
         {
             ReadInternal(buffer, 1);
             return buffer[0];
@@ -148,17 +148,17 @@ namespace MiscUtil.IO
         /// Reads a single signed byte from the stream.
         /// </summary>
         /// <returns>The byte read</returns>
-        public sbyte ReadSByte()
+        public SByte ReadSByte()
         {
             ReadInternal(buffer, 1);
-            return unchecked((sbyte)buffer[0]);
+            return unchecked((SByte)buffer[0]);
         }
 
         /// <summary>
         /// Reads a boolean from the stream. 1 byte is read.
         /// </summary>
         /// <returns>The boolean read</returns>
-        public bool ReadBoolean()
+        public Boolean ReadBoolean()
         {
             ReadInternal(buffer, 1);
             return bitConverter.ToBoolean(buffer, 0);
@@ -169,7 +169,7 @@ namespace MiscUtil.IO
         /// for this reader. 2 bytes are read.
         /// </summary>
         /// <returns>The 16-bit integer read</returns>
-        public short ReadInt16()
+        public Int16 ReadInt16()
         {
             ReadInternal(buffer, 2);
             return bitConverter.ToInt16(buffer, 0);
@@ -180,7 +180,7 @@ namespace MiscUtil.IO
         /// for this reader. 4 bytes are read.
         /// </summary>
         /// <returns>The 32-bit integer read</returns>
-        public int ReadInt32()
+        public Int32 ReadInt32()
         {
             ReadInternal(buffer, 4);
             return bitConverter.ToInt32(buffer, 0);
@@ -191,7 +191,7 @@ namespace MiscUtil.IO
         /// for this reader. 8 bytes are read.
         /// </summary>
         /// <returns>The 64-bit integer read</returns>
-        public long ReadInt64()
+        public Int64 ReadInt64()
         {
             ReadInternal(buffer, 8);
             return bitConverter.ToInt64(buffer, 0);
@@ -202,7 +202,7 @@ namespace MiscUtil.IO
         /// for this reader. 2 bytes are read.
         /// </summary>
         /// <returns>The 16-bit unsigned integer read</returns>
-        public ushort ReadUInt16()
+        public UInt16 ReadUInt16()
         {
             ReadInternal(buffer, 2);
             return bitConverter.ToUInt16(buffer, 0);
@@ -213,7 +213,7 @@ namespace MiscUtil.IO
         /// for this reader. 4 bytes are read.
         /// </summary>
         /// <returns>The 32-bit unsigned integer read</returns>
-        public uint ReadUInt32()
+        public UInt32 ReadUInt32()
         {
             ReadInternal(buffer, 4);
             return bitConverter.ToUInt32(buffer, 0);
@@ -224,7 +224,7 @@ namespace MiscUtil.IO
         /// for this reader. 8 bytes are read.
         /// </summary>
         /// <returns>The 64-bit unsigned integer read</returns>
-        public ulong ReadUInt64()
+        public UInt64 ReadUInt64()
         {
             ReadInternal(buffer, 8);
             return bitConverter.ToUInt64(buffer, 0);
@@ -235,7 +235,7 @@ namespace MiscUtil.IO
         /// for this reader. 4 bytes are read.
         /// </summary>
         /// <returns>The floating point value read</returns>
-        public float ReadSingle()
+        public Single ReadSingle()
         {
             ReadInternal(buffer, 4);
             return bitConverter.ToSingle(buffer, 0);
@@ -246,7 +246,7 @@ namespace MiscUtil.IO
         /// for this reader. 8 bytes are read.
         /// </summary>
         /// <returns>The floating point value read</returns>
-        public double ReadDouble()
+        public Double ReadDouble()
         {
             ReadInternal(buffer, 8);
             return bitConverter.ToDouble(buffer, 0);
@@ -257,7 +257,7 @@ namespace MiscUtil.IO
         /// for this reader. 16 bytes are read.
         /// </summary>
         /// <returns>The decimal value read</returns>
-        public decimal ReadDecimal()
+        public Decimal ReadDecimal()
         {
             ReadInternal(buffer, 16);
             return bitConverter.ToDecimal(buffer, 0);
@@ -269,9 +269,9 @@ namespace MiscUtil.IO
         /// -1 is returned.
         /// </summary>
         /// <returns>The character read, or -1 for end of stream.</returns>
-        public int Read()
+        public Int32 Read()
         {
-            int charsRead = Read(charBuffer, 0, 1);
+            Int32 charsRead = Read(charBuffer, 0, 1);
             if (charsRead==0)
             {
                 return -1;
@@ -292,7 +292,7 @@ namespace MiscUtil.IO
         /// <returns>The number of characters actually read. This will only be less than
         /// the requested number of characters if the end of the stream is reached.
         /// </returns>
-        public int Read(char[] data, int index, int count)
+        public Int32 Read(Char[] data, Int32 index, Int32 count)
         {
             CheckDisposed();
             if (buffer==null)
@@ -313,21 +313,21 @@ namespace MiscUtil.IO
                     ("Not enough space in buffer for specified number of characters starting at specified index");
             }
 
-            int read=0;
-            bool firstTime=true;
+            Int32 read=0;
+            Boolean firstTime=true;
 
             // Use the normal buffer if we're only reading a small amount, otherwise
             // use at most 4K at a time.
-            byte[] byteBuffer = buffer;
+            Byte[] byteBuffer = buffer;
 
             if (byteBuffer.Length < count*minBytesPerChar)
             {
-                byteBuffer = new byte[4096];
+                byteBuffer = new Byte[4096];
             }
 
             while (read < count)
             {
-                int amountToRead;
+                Int32 amountToRead;
                 // First time through we know we haven't previously read any data
                 if (firstTime)
                 {
@@ -344,12 +344,12 @@ namespace MiscUtil.IO
                 {
                     amountToRead = byteBuffer.Length;
                 }
-                int bytesRead = TryReadInternal(byteBuffer, amountToRead);
+                Int32 bytesRead = TryReadInternal(byteBuffer, amountToRead);
                 if (bytesRead==0)
                 {
                     return read;
                 }
-                int decoded = decoder.GetChars(byteBuffer, 0, bytesRead, data, index);
+                Int32 decoded = decoder.GetChars(byteBuffer, 0, bytesRead, data, index);
                 read += decoded;
                 index += decoded;
             }
@@ -366,7 +366,7 @@ namespace MiscUtil.IO
         /// <returns>The number of bytes actually read. This will only be less than
         /// the requested number of bytes if the end of the stream is reached.
         /// </returns>
-        public int Read(byte[] buffer, int index, int count)
+        public Int32 Read(Byte[] buffer, Int32 index, Int32 count)
         {
             CheckDisposed();
             if (buffer==null)
@@ -386,10 +386,10 @@ namespace MiscUtil.IO
                 throw new ArgumentException
                     ("Not enough space in buffer for specified number of bytes starting at specified index");
             }
-            int read=0;
+            Int32 read=0;
             while (count > 0)
             {
-                int block = stream.Read(buffer, index, count);
+                Int32 block = stream.Read(buffer, index, count);
                 if (block==0)
                 {
                     return read;
@@ -408,22 +408,22 @@ namespace MiscUtil.IO
         /// </summary>
         /// <param name="count">The number of bytes to read</param>
         /// <returns>The bytes read</returns>
-        public byte[] ReadBytes(int count)
+        public Byte[] ReadBytes(Int32 count)
         {
             CheckDisposed();
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException("count");
             }
-            byte[] ret = new byte[count];
-            int index=0;
+            Byte[] ret = new Byte[count];
+            Int32 index=0;
             while (index < count)
             {
-                int read = stream.Read(ret, index, count-index);
+                Int32 read = stream.Read(ret, index, count-index);
                 // Stream has finished half way through. That's fine, return what we've got.
                 if (read==0)
                 {
-                    byte[] copy = new byte[index];
+                    Byte[] copy = new Byte[index];
                     Buffer.BlockCopy(ret, 0, copy, 0, index);
                     return copy;
                 }
@@ -439,9 +439,9 @@ namespace MiscUtil.IO
         /// </summary>
         /// <param name="count">The number of bytes to read</param>
         /// <returns>The bytes read</returns>
-        public byte[] ReadBytesOrThrow(int count)
+        public Byte[] ReadBytesOrThrow(Int32 count)
         {
-            byte[] ret = new byte[count];
+            Byte[] ret = new Byte[count];
             ReadInternal(ret, count);
             return ret;
         }
@@ -453,14 +453,14 @@ namespace MiscUtil.IO
         /// of the bit converter.
         /// </summary>
         /// <returns>The 7-bit encoded integer read from the stream.</returns>
-        public int Read7BitEncodedInt()
+        public Int32 Read7BitEncodedInt()
         {
             CheckDisposed();
 
-            int ret=0;
-            for (int shift = 0; shift < 35; shift+=7)
+            Int32 ret=0;
+            for (Int32 shift = 0; shift < 35; shift+=7)
             {
-                int b = stream.ReadByte();
+                Int32 b = stream.ReadByte();
                 if (b==-1)
                 {
                     throw new EndOfStreamException();
@@ -482,14 +482,14 @@ namespace MiscUtil.IO
         /// of the bit converter.
         /// </summary>
         /// <returns>The 7-bit encoded integer read from the stream.</returns>
-        public int ReadBigEndian7BitEncodedInt()
+        public Int32 ReadBigEndian7BitEncodedInt()
         {
             CheckDisposed();
 
-            int ret=0;
-            for (int i=0; i < 5; i++)
+            Int32 ret=0;
+            for (Int32 i=0; i < 5; i++)
             {
-                int b = stream.ReadByte();
+                Int32 b = stream.ReadByte();
                 if (b==-1)
                 {
                     throw new EndOfStreamException();
@@ -511,11 +511,11 @@ namespace MiscUtil.IO
         /// the encoding for this reader.
         /// </summary>
         /// <returns>The string read from the stream.</returns>
-        public string ReadString()
+        public String ReadString()
         {
-            int bytesToRead = Read7BitEncodedInt();
+            Int32 bytesToRead = Read7BitEncodedInt();
 
-            byte[] data = new byte[bytesToRead];
+            Byte[] data = new Byte[bytesToRead];
             ReadInternal(data, bytesToRead);
             return encoding.GetString(data, 0, data.Length);
         }
@@ -540,13 +540,13 @@ namespace MiscUtil.IO
         /// </summary>
         /// <param name="data">Buffer to read into</param>
         /// <param name="size">Number of bytes to read</param>
-        void ReadInternal (byte[] data, int size)
+        void ReadInternal (Byte[] data, Int32 size)
         {
             CheckDisposed();
-            int index=0;
+            Int32 index=0;
             while (index < size)
             {
-                int read = stream.Read(data, index, size-index);
+                Int32 read = stream.Read(data, index, size-index);
                 if (read==0)
                 {
                     throw new EndOfStreamException
@@ -565,13 +565,13 @@ namespace MiscUtil.IO
         /// <param name="data">Buffer to read into</param>
         /// <param name="size">Number of bytes to read</param>
         /// <returns>Number of bytes actually read</returns>
-        int TryReadInternal (byte[] data, int size)
+        Int32 TryReadInternal (Byte[] data, Int32 size)
         {
             CheckDisposed();
-            int index=0;
+            Int32 index=0;
             while (index < size)
             {
-                int read = stream.Read(data, index, size-index);
+                Int32 read = stream.Read(data, index, size-index);
                 if (read==0)
                 {
                     return index;

--- a/PacketDotNet/MiscUtil/IO/EndianBinaryWriter.cs
+++ b/PacketDotNet/MiscUtil/IO/EndianBinaryWriter.cs
@@ -15,15 +15,15 @@ namespace MiscUtil.IO
         /// <summary>
         /// Whether or not this writer has been disposed yet.
         /// </summary>
-        bool disposed=false;
+        Boolean disposed=false;
         /// <summary>
         /// Buffer used for temporary storage during conversion from primitives
         /// </summary>
-        byte[] buffer = new byte[16];
+        Byte[] buffer = new Byte[16];
         /// <summary>
         /// Buffer used for Write(char)
         /// </summary>
-        char[] charBuffer = new char[1];
+        Char[] charBuffer = new Char[1];
         #endregion
 
         #region Constructors
@@ -121,7 +121,7 @@ namespace MiscUtil.IO
         /// </summary>
         /// <param name="offset">Offset to seek to.</param>
         /// <param name="origin">Origin of seek operation.</param>
-        public void Seek (int offset, SeekOrigin origin)
+        public void Seek (Int32 offset, SeekOrigin origin)
         {
             CheckDisposed();
             stream.Seek (offset, origin);
@@ -131,7 +131,7 @@ namespace MiscUtil.IO
         /// Writes a boolean value to the stream. 1 byte is written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (bool value)
+        public void Write (Boolean value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 1);
@@ -142,7 +142,7 @@ namespace MiscUtil.IO
         /// for this writer. 2 bytes are written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (short value)
+        public void Write (Int16 value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 2);
@@ -153,7 +153,7 @@ namespace MiscUtil.IO
         /// for this writer. 4 bytes are written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (int value)
+        public void Write (Int32 value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 4);
@@ -164,7 +164,7 @@ namespace MiscUtil.IO
         /// for this writer. 8 bytes are written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (long value)
+        public void Write (Int64 value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 8);
@@ -175,7 +175,7 @@ namespace MiscUtil.IO
         /// for this writer. 2 bytes are written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (ushort value)
+        public void Write (UInt16 value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 2);
@@ -186,7 +186,7 @@ namespace MiscUtil.IO
         /// for this writer. 4 bytes are written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (uint value)
+        public void Write (UInt32 value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 4);
@@ -197,7 +197,7 @@ namespace MiscUtil.IO
         /// for this writer. 8 bytes are written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (ulong value)
+        public void Write (UInt64 value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 8);
@@ -208,7 +208,7 @@ namespace MiscUtil.IO
         /// for this writer. 4 bytes are written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (float value)
+        public void Write (Single value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 4);
@@ -219,7 +219,7 @@ namespace MiscUtil.IO
         /// for this writer. 8 bytes are written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (double value)
+        public void Write (Double value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 8);
@@ -230,7 +230,7 @@ namespace MiscUtil.IO
         /// 16 bytes are written.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (decimal value)
+        public void Write (Decimal value)
         {
             bitConverter.CopyBytes(value, buffer, 0);
             WriteInternal(buffer, 16);
@@ -240,7 +240,7 @@ namespace MiscUtil.IO
         /// Writes a signed byte to the stream.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (byte value)
+        public void Write (Byte value)
         {
             buffer[0] = value;
             WriteInternal(buffer, 1);
@@ -250,9 +250,9 @@ namespace MiscUtil.IO
         /// Writes an unsigned byte to the stream.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write (sbyte value)
+        public void Write (SByte value)
         {
-            buffer[0] = unchecked((byte)value);
+            buffer[0] = unchecked((Byte)value);
             WriteInternal(buffer, 1);
         }
 
@@ -260,7 +260,7 @@ namespace MiscUtil.IO
         /// Writes an array of bytes to the stream.
         /// </summary>
         /// <param name="value">The values to write</param>
-        public void Write (byte[] value)
+        public void Write (Byte[] value)
         {
             if (value == null)
             {
@@ -275,7 +275,7 @@ namespace MiscUtil.IO
         /// <param name="value">An array containing the bytes to write</param>
         /// <param name="offset">The index of the first byte to write within the array</param>
         /// <param name="count">The number of bytes to write</param>
-        public void Write (byte[] value, int offset, int count)
+        public void Write (Byte[] value, Int32 offset, Int32 count)
         {
             CheckDisposed();
             stream.Write(value, offset, count);
@@ -285,7 +285,7 @@ namespace MiscUtil.IO
         /// Writes a single character to the stream, using the encoding for this writer.
         /// </summary>
         /// <param name="value">The value to write</param>
-        public void Write(char value)
+        public void Write(Char value)
         {
             charBuffer[0] = value;
             Write(charBuffer);
@@ -295,14 +295,14 @@ namespace MiscUtil.IO
         /// Writes an array of characters to the stream, using the encoding for this writer.
         /// </summary>
         /// <param name="value">An array containing the characters to write</param>
-        public void Write(char[] value)
+        public void Write(Char[] value)
         {
             if (value==null)
             {
                 throw new ArgumentNullException("value");
             }
             CheckDisposed();
-            byte[] data = Encoding.GetBytes(value, 0, value.Length);
+            Byte[] data = Encoding.GetBytes(value, 0, value.Length);
             WriteInternal(data, data.Length);
         }
 
@@ -311,14 +311,14 @@ namespace MiscUtil.IO
         /// </summary>
         /// <param name="value">The value to write. Must not be null.</param>
         /// <exception cref="ArgumentNullException">value is null</exception>
-        public void Write(string value)
+        public void Write(String value)
         {
             if (value==null)
             {
                 throw new ArgumentNullException("value");
             }
             CheckDisposed();
-            byte[] data = Encoding.GetBytes(value);
+            Byte[] data = Encoding.GetBytes(value);
             Write7BitEncodedInt(data.Length);
             WriteInternal(data, data.Length);
         }
@@ -329,21 +329,21 @@ namespace MiscUtil.IO
         /// bit as a continuation flag.
         /// </summary>
         /// <param name="value">The 7-bit encoded integer to write to the stream</param>
-        public void Write7BitEncodedInt(int value)
+        public void Write7BitEncodedInt(Int32 value)
         {
             CheckDisposed();
             if (value < 0)
             {
                 throw new ArgumentOutOfRangeException("value", "Value must be greater than or equal to 0.");
             }
-            int index=0;
+            Int32 index=0;
             while (value >= 128)
             {
-                buffer[index++]= (byte)((value&0x7f) | 0x80);
+                buffer[index++]= (Byte)((value&0x7f) | 0x80);
                 value = value >> 7;
                 index++;
             }
-            buffer[index++]=(byte)value;
+            buffer[index++]=(Byte)value;
             stream.Write(buffer, 0, index);
         }
 
@@ -367,7 +367,7 @@ namespace MiscUtil.IO
         /// </summary>
         /// <param name="bytes">The array of bytes to write from</param>
         /// <param name="length">The number of bytes to write</param>
-        void WriteInternal (byte[] bytes, int length)
+        void WriteInternal (Byte[] bytes, Int32 length)
         {
             CheckDisposed();
             stream.Write(bytes, 0, length);

--- a/PacketDotNet/NullFields.cs
+++ b/PacketDotNet/NullFields.cs
@@ -29,16 +29,16 @@ namespace PacketDotNet
         /// <summary>
         /// Length of the Protocol field in bytes, the field is of type
         /// </summary>
-        public static readonly int ProtocolLength = 4;
+        public static readonly Int32 ProtocolLength = 4;
 
         /// <summary>
         /// Offset from the start of the packet where the Protocol field is located
         /// </summary>
-        public static readonly int ProtocolPosition = 0;
+        public static readonly Int32 ProtocolPosition = 0;
 
         /// <summary>
         /// The length of the header
         /// </summary>
-        public static readonly int HeaderLength = ProtocolLength;
+        public static readonly Int32 HeaderLength = ProtocolLength;
     }
 }

--- a/PacketDotNet/NullPacket.cs
+++ b/PacketDotNet/NullPacket.cs
@@ -70,9 +70,9 @@ namespace PacketDotNet
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int length = NullFields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = NullFields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             // setup some typical values and default values
@@ -135,7 +135,7 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
             buffer.Append(base.ToString(outputFormat));

--- a/PacketDotNet/OSPFPacket.cs
+++ b/PacketDotNet/OSPFPacket.cs
@@ -35,9 +35,9 @@ namespace PacketDotNet
         /// <param name="payload">The bytes from which the packet is conctructed</param>
         /// <param name="offset">The offset of this packet from the parent packet</param>
         /// <returns>an OSPF packet</returns>
-        public static OSPFPacket ConstructOSPFPacket(byte[] payload, int offset)
+        public static OSPFPacket ConstructOSPFPacket(Byte[] payload, Int32 offset)
         {
-            byte v = payload[offset + OSPFv2Fields.VersionPosition];
+            Byte v = payload[offset + OSPFv2Fields.VersionPosition];
 
             if (!Enum.IsDefined(typeof(OSPFVersion), v))
             {
@@ -57,7 +57,7 @@ namespace PacketDotNet
             }
         }
 
-        private static OSPFv2Packet ConstructV2Packet(byte[] payload, int offset)
+        private static OSPFv2Packet ConstructV2Packet(Byte[] payload, Int32 offset)
         {
             OSPFv2Packet p;
             OSPFPacketType type = (OSPFPacketType)payload[offset + OSPFv2Fields.TypePosition];
@@ -86,7 +86,7 @@ namespace PacketDotNet
             return p;
         }
 
-        private static OSPFPacket ConstructV3Packet(byte[] payload, int offset)
+        private static OSPFPacket ConstructV3Packet(Byte[] payload, Int32 offset)
         {
             throw new NotImplementedException("OSPFv3 is not supported yet");
         }

--- a/PacketDotNet/OSPFv2Fields.cs
+++ b/PacketDotNet/OSPFv2Fields.cs
@@ -18,167 +18,169 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
  *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>
  */
 
+using System;
+
 namespace PacketDotNet
 {
     internal class OSPFv2Fields
     {
         /// <summary> Length of the OSPF packet version in bytes.</summary>
-        public static readonly int VersionLength = 1;
+        public static readonly Int32 VersionLength = 1;
 
         /// <summary> Length of the OSPF header type in bytes.</summary>
-        public static readonly int TypeLength = 1;
+        public static readonly Int32 TypeLength = 1;
 
         /// <summary> Length of the OSPF packet in bytes.</summary>
-        public static readonly int PacketLength = 2;
+        public static readonly Int32 PacketLength = 2;
 
         /// <summary> Length of the OSPF router ID (ip) field in bytes </summary>
-        public static readonly int RouterIDLength = 4;
+        public static readonly Int32 RouterIDLength = 4;
 
         /// <summary> Length of the OSPF area ID (ip) field in bytes </summary>
-        public static readonly int AreaIDLength = 4;
+        public static readonly Int32 AreaIDLength = 4;
 
         /// <summary> Length of the OSPF checksum in bytes </summary>
-        public static readonly int ChecksumLength = 2;
+        public static readonly Int32 ChecksumLength = 2;
 
         /// <summary> Length of the OSPF instance AuType field in bytes </summary>
-        public static readonly int AuTypeLength = 2;
+        public static readonly Int32 AuTypeLength = 2;
 
         /// <summary> One padding byte at the end of the header </summary>
-        public static readonly int AuthorizationLength = 8;
+        public static readonly Int32 AuthorizationLength = 8;
 
         /// <summary> Position of the OSPF version.</summary>
-        public static readonly int VersionPosition;
+        public static readonly Int32 VersionPosition;
 
         /// <summary> Position of the the OSPF packet type.</summary>
-        public static readonly int TypePosition;
+        public static readonly Int32 TypePosition;
 
         /// <summary> Position of the OSPF packet length </summary>
-        public static readonly int PacketLengthPosition;
+        public static readonly Int32 PacketLengthPosition;
 
         /// <summary> Position of the RouterID field </summary>
-        public static readonly int RouterIDPosition;
+        public static readonly Int32 RouterIDPosition;
 
         /// <summary> Position of the AreaID field </summary>
-        public static readonly int AreaIDPosition;
+        public static readonly Int32 AreaIDPosition;
 
         /// <summary> Position of the OSPF packet checksum </summary>
-        public static readonly int ChecksumPosition;
+        public static readonly Int32 ChecksumPosition;
 
         /// <summary> Position of the AuType field </summary>
-        public static readonly int AuTypePosition;
+        public static readonly Int32 AuTypePosition;
 
         /// <summary> Position of the Authorization bytes </summary>
-        public static readonly int AuthorizationPosition;
+        public static readonly Int32 AuthorizationPosition;
 
         /// <summary> Length in bytes of an OSPF header.</summary>
-        public static readonly int HeaderLength;
+        public static readonly Int32 HeaderLength;
 
         // ------------------ ospf hello packet stuff
 
         /// <summary> Length of NetworkMask in bytes.</summary>
-        public static readonly int NetworkMaskLength = 4;
+        public static readonly Int32 NetworkMaskLength = 4;
 
         /// <summary> Length of the Hello Interaval in bytes.</summary>
-        public static readonly int HelloIntervalLength = 2;
+        public static readonly Int32 HelloIntervalLength = 2;
 
         /// <summary> Length of the options in bytes.</summary>
-        public static readonly int HelloOptionsLength = 1;
+        public static readonly Int32 HelloOptionsLength = 1;
 
         /// <summary> Length of RTR priority in bytes.</summary>
-        public static readonly int RtrPriorityLength = 1;
+        public static readonly Int32 RtrPriorityLength = 1;
 
         /// <summary> Length of the Router Dead Interval field in bytes </summary>
-        public static readonly int RouterDeadIntervalLength = 4;
+        public static readonly Int32 RouterDeadIntervalLength = 4;
 
         /// <summary> Length of the Designated Router ID (ip) field in bytes </summary>
-        public static readonly int DesignatedRouterIDLength = 4;
+        public static readonly Int32 DesignatedRouterIDLength = 4;
 
         /// <summary> Length of the Backup Designated Router in bytes </summary>
-        public static readonly int BackupRouterIDLength = 4;
+        public static readonly Int32 BackupRouterIDLength = 4;
 
         /// <summary> Length of the Neighbor ID field in bytes </summary>
-        public static readonly int NeighborIDLength = 4;
+        public static readonly Int32 NeighborIDLength = 4;
 
         /// <summary> Positon of the Networkmask.</summary>
-        public static readonly int NetworkMaskPositon;
+        public static readonly Int32 NetworkMaskPositon;
 
         /// <summary> Position of the Hello Interaval.</summary>
-        public static readonly int HelloIntervalPosition;
+        public static readonly Int32 HelloIntervalPosition;
 
         /// <summary> Position of the options.</summary>
-        public static readonly int HelloOptionsPosition;
+        public static readonly Int32 HelloOptionsPosition;
 
         /// <summary> Position of RTR priority.</summary>
-        public static readonly int RtrPriorityPosition;
+        public static readonly Int32 RtrPriorityPosition;
 
         /// <summary> Position of the Router Dead Interval.</summary>
-        public static readonly int RouterDeadIntervalPosition;
+        public static readonly Int32 RouterDeadIntervalPosition;
 
         /// <summary> Position of the Designated Router ID (ip).</summary>
-        public static readonly int DesignatedRouterIDPosition;
+        public static readonly Int32 DesignatedRouterIDPosition;
 
         /// <summary> Position of the Backup Designated Router.</summary>
-        public static readonly int BackupRouterIDPosition;
+        public static readonly Int32 BackupRouterIDPosition;
 
         /// <summary> Start of the NeighborIDs (zero or more).</summary>
-        public static readonly int NeighborIDStart;
+        public static readonly Int32 NeighborIDStart;
 
         /// <summary> Length of the hello packet.</summary>
-        public static readonly int HelloPacketLength;
+        public static readonly Int32 HelloPacketLength;
 
         // ------------------ ospf database description packet stuff
 
         /// <summary> Length of InterfaceMTU in bytes.</summary>
-        public static readonly int InterfaceMTULength = 2;
+        public static readonly Int32 InterfaceMTULength = 2;
 
         /// <summary> Length of the options in bytes.</summary>
-        public static readonly int DBDescriptionOptionsLength = 1;
+        public static readonly Int32 DBDescriptionOptionsLength = 1;
 
         /// <summary> Length of optional bits in bytes.</summary>
-        public static readonly int BitsLength = 1;
+        public static readonly Int32 BitsLength = 1;
 
         /// <summary> Length of the DD sequence field in bytes </summary>
-        public static readonly int DDSequenceLength = 4;
+        public static readonly Int32 DDSequenceLength = 4;
 
         /// <summary> Length of the LSA header in bytes </summary>
-        public static readonly int LSAHeaderLength = 20;
+        public static readonly Int32 LSAHeaderLength = 20;
 
         /// <summary> Position of InterfaceMTU.</summary>
-        public static readonly int InterfaceMTUPosition;
+        public static readonly Int32 InterfaceMTUPosition;
 
         /// <summary> Position of DB description options.</summary>
-        public static readonly int DBDescriptionOptionsPosition;
+        public static readonly Int32 DBDescriptionOptionsPosition;
 
         /// <summary> Positon of the optional bits.</summary>
-        public static readonly int BitsPosition;
+        public static readonly Int32 BitsPosition;
 
         /// <summary> Positon of the DD sequence. </summary>
-        public static readonly int DDSequencePosition;
+        public static readonly Int32 DDSequencePosition;
 
         /// <summary> Positon of the LSA header. </summary>
-        public static readonly int LSAHeaderPosition;
+        public static readonly Int32 LSAHeaderPosition;
 
         // ------------------ ospf link state request packet stuff
         /// <summary> The start of the link state requests.</summary>
-        public static readonly int LSRStart;
+        public static readonly Int32 LSRStart;
 
         // ------------------ ospf link state update
 
         /// <summary> Length of the LSA# field</summary>
-        public static readonly int LSANumberLength = 4;
+        public static readonly Int32 LSANumberLength = 4;
 
         /// <summary> Positon of the LSA#.</summary>
-        public static readonly int LSANumberPosition;
+        public static readonly Int32 LSANumberPosition;
 
         /// <summary> Positon of the LSA Updates.</summary>
-        public static readonly int LSAUpdatesPositon;
+        public static readonly Int32 LSAUpdatesPositon;
 
         // ------------------ ospf link state ack
         /// <summary> Length of the LSA acknowledge</summary>
-        public static readonly int LSAAckLength = 20;
+        public static readonly Int32 LSAAckLength = 20;
 
         /// <summary> Position of the LSA acknowledge</summary>
-        public static readonly int LSAAckPosition;
+        public static readonly Int32 LSAAckPosition;
 
         static OSPFv2Fields()
         {

--- a/PacketDotNet/OSPFv2Packet.cs
+++ b/PacketDotNet/OSPFv2Packet.cs
@@ -56,9 +56,9 @@ namespace PacketDotNet
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int length = OSPFv2Fields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = OSPFv2Fields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             this.Version = ospfVersion;
@@ -67,7 +67,7 @@ namespace PacketDotNet
         /// <summary>
         /// Constructs a packet from bytes and offset
         /// </summary>
-        public OSPFv2Packet(byte[] Bytes, int Offset)
+        public OSPFv2Packet(Byte[] Bytes, Int32 Offset)
         {
             log.Debug("");
             header = new ByteArraySegment(Bytes, Offset, OSPFv2Fields.HeaderLength);
@@ -86,7 +86,7 @@ namespace PacketDotNet
 
             set
             {
-                header.Bytes[header.Offset + OSPFv2Fields.VersionPosition] = (byte)value;
+                header.Bytes[header.Offset + OSPFv2Fields.VersionPosition] = (Byte)value;
             }
         }
 
@@ -106,14 +106,14 @@ namespace PacketDotNet
             }
             set
             {
-                header.Bytes[header.Offset + OSPFv2Fields.TypePosition] = (byte)value;
+                header.Bytes[header.Offset + OSPFv2Fields.TypePosition] = (Byte)value;
             }
         }
 
         /// <summary>
         /// The length of the OSPF protocol packet in bytes.
         /// </summary>
-        public virtual ushort PacketLength
+        public virtual UInt16 PacketLength
         {
             get
             {
@@ -137,7 +137,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + OSPFv2Fields.RouterIDPosition,
                            address.Length);
@@ -156,7 +156,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + OSPFv2Fields.AreaIDPosition,
                            address.Length);
@@ -167,7 +167,7 @@ namespace PacketDotNet
         /// The standard IP checksum of the entire contents of the packet,
         /// except the 64-bit authentication field
         /// </summary>
-        public virtual ushort Checksum
+        public virtual UInt16 Checksum
         {
             get
             {
@@ -182,7 +182,7 @@ namespace PacketDotNet
         /// <summary>
         /// Authentication procedure. See http://www.ietf.org/rfc/rfc2328.txt for details.
         /// </summary>
-        public virtual ushort AuType
+        public virtual UInt16 AuType
         {
             get
             {
@@ -197,7 +197,7 @@ namespace PacketDotNet
         ///<summary>
         /// A 64-bit field for use by the authentication scheme
         /// </summary>
-        public virtual ulong Authentication
+        public virtual UInt64 Authentication
         {
             get
             {
@@ -213,7 +213,7 @@ namespace PacketDotNet
         /// Returns a <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2Packet"/>.
         /// </summary>
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2Packet"/>.</returns>
-        public override string ToString()
+        public override String ToString()
         {
             StringBuilder packet = new StringBuilder();
             packet.AppendFormat("OSPFv2 packet, type {0} ", this.Type);
@@ -231,7 +231,7 @@ namespace PacketDotNet
         /// </summary>
         /// <returns>The string.</returns>
         /// <param name="outputFormat">Output format.</param>
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             return ToString();
         }
@@ -269,10 +269,10 @@ namespace PacketDotNet
         /// <param name="NetworkMask">The Network mask - see http://www.ietf.org/rfc/rfc2328.txt for details.</param>
         /// <param name="HelloInterval">The Hello interval - see http://www.ietf.org/rfc/rfc2328.txt for details.</param>
         /// <param name="RouterDeadInterval">The Router dead interval - see http://www.ietf.org/rfc/rfc2328.txt for details.</param>
-        public OSPFv2HelloPacket(System.Net.IPAddress NetworkMask, ushort HelloInterval,
-                                 ushort RouterDeadInterval)
+        public OSPFv2HelloPacket(System.Net.IPAddress NetworkMask, UInt16 HelloInterval,
+                                 UInt16 RouterDeadInterval)
         {
-            byte[] b = new byte[OSPFv2Fields.NeighborIDStart];
+            Byte[] b = new Byte[OSPFv2Fields.NeighborIDStart];
             Array.Copy(header.Bytes, b, header.Bytes.Length);
             this.header = new ByteArraySegment(b, 0, OSPFv2Fields.NeighborIDStart);
             this.Type = packetType;
@@ -280,7 +280,7 @@ namespace PacketDotNet
             this.NetworkMask = NetworkMask;
             this.HelloInterval = HelloInterval;
             this.RouterDeadInterval = RouterDeadInterval;
-            this.PacketLength = (ushort)header.Bytes.Length;
+            this.PacketLength = (UInt16)header.Bytes.Length;
         }
 
         /// <summary>
@@ -291,23 +291,23 @@ namespace PacketDotNet
         /// <param name="HelloInterval">The Hello interval - see http://www.ietf.org/rfc/rfc2328.txt for details.</param>
         /// <param name="RouterDeadInterval">The Router dead interval - see http://www.ietf.org/rfc/rfc2328.txt for details.</param>
         /// <param name="Neighbors">List of router neighbors - see http://www.ietf.org/rfc/rfc2328.txt for details.</param>
-        public OSPFv2HelloPacket(System.Net.IPAddress NetworkMask, ushort HelloInterval,
-                                 ushort RouterDeadInterval, List<System.Net.IPAddress> Neighbors)
+        public OSPFv2HelloPacket(System.Net.IPAddress NetworkMask, UInt16 HelloInterval,
+                                 UInt16 RouterDeadInterval, List<System.Net.IPAddress> Neighbors)
             : this(NetworkMask, HelloInterval, RouterDeadInterval)
         {
-            int length = Neighbors.Count * 4;
-            int offset = OSPFv2Fields.NeighborIDStart;
-            byte[] bytes = new byte[length + OSPFv2Fields.NeighborIDStart];
+            Int32 length = Neighbors.Count * 4;
+            Int32 offset = OSPFv2Fields.NeighborIDStart;
+            Byte[] bytes = new Byte[length + OSPFv2Fields.NeighborIDStart];
 
             Array.Copy(header.Bytes, bytes, header.Length);
-            for (int i = 0; i < Neighbors.Count; i++)
+            for (Int32 i = 0; i < Neighbors.Count; i++)
             {
                 Array.Copy(Neighbors[i].GetAddressBytes(), 0, bytes, offset, 4); //4 bytes per address
                 offset += 4;
             }
 
             header = new ByteArraySegment(bytes);
-            this.PacketLength = (ushort)header.Bytes.Length;
+            this.PacketLength = (UInt16)header.Bytes.Length;
         }
 
         /// <summary>
@@ -319,7 +319,7 @@ namespace PacketDotNet
         /// <param name="Offset">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public OSPFv2HelloPacket(byte[] Bytes, int Offset) :
+        public OSPFv2HelloPacket(Byte[] Bytes, Int32 Offset) :
             base(Bytes, Offset)
         {
             this.Type = packetType;
@@ -337,7 +337,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + OSPFv2Fields.NetworkMaskPositon,
                            address.Length);
@@ -347,7 +347,7 @@ namespace PacketDotNet
         /// <summary>
         /// The number of seconds between this router's Hello packets.
         /// </summary>
-        public virtual ushort HelloInterval
+        public virtual UInt16 HelloInterval
         {
             get
             {
@@ -362,7 +362,7 @@ namespace PacketDotNet
         /// <summary>
         /// The optional capabilities supported by the router. See http://www.ietf.org/rfc/rfc2328.txt for details.
         /// </summary>
-        public virtual byte HelloOptions
+        public virtual Byte HelloOptions
         {
             get
             {
@@ -377,7 +377,7 @@ namespace PacketDotNet
         /// <summary>
         /// This router's Router Priority.
         /// </summary>
-        public virtual byte RtrPriority
+        public virtual Byte RtrPriority
         {
             get
             {
@@ -393,7 +393,7 @@ namespace PacketDotNet
         /// <summary>
         /// The number of seconds before declaring a silent router down.
         /// </summary>
-        public virtual uint RouterDeadInterval
+        public virtual UInt32 RouterDeadInterval
         {
             get
             {
@@ -418,7 +418,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + OSPFv2Fields.DesignatedRouterIDPosition,
                            address.Length);
@@ -439,7 +439,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] address = value.GetAddressBytes();
+                Byte[] address = value.GetAddressBytes();
                 Array.Copy(address, 0,
                            header.Bytes, header.Offset + OSPFv2Fields.BackupRouterIDPosition,
                            address.Length);
@@ -456,17 +456,17 @@ namespace PacketDotNet
             get
             {
                 List<System.Net.IPAddress> ret = new List<System.Net.IPAddress>();
-                int bytesAvailable = this.PacketLength - OSPFv2Fields.NeighborIDStart;
+                Int32 bytesAvailable = this.PacketLength - OSPFv2Fields.NeighborIDStart;
 
                 if (bytesAvailable % 4 != 0)
                 {
                     throw new Exception("malformed OSPFv2Hello Packet - bad NeighborID size");
                 }
 
-                int offset = OSPFv2Fields.NeighborIDStart;
+                Int32 offset = OSPFv2Fields.NeighborIDStart;
                 while (offset < this.PacketLength)
                 {
-                    long address = EndianBitConverter.Little.ToUInt32(header.Bytes, header.Offset + offset);
+                    Int64 address = EndianBitConverter.Little.ToUInt32(header.Bytes, header.Offset + offset);
                     ret.Add(new System.Net.IPAddress(address));
                     offset += 4;
                 }
@@ -478,7 +478,7 @@ namespace PacketDotNet
         /// Returns a <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2HelloPacket"/>.
         /// </summary>
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2HelloPacket"/>.</returns>
-        public override string ToString()
+        public override String ToString()
         {
             StringBuilder packet = new StringBuilder();
             packet.Append(base.ToString());
@@ -497,7 +497,7 @@ namespace PacketDotNet
         /// </summary>
         /// <returns>The string.</returns>
         /// <param name="outputFormat">Output format.</param>
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             return ToString();
         }
@@ -531,12 +531,12 @@ namespace PacketDotNet
         /// </summary>
         public OSPFv2DDPacket()
         {
-            byte[] b = new byte[OSPFv2Fields.LSAHeaderPosition];
+            Byte[] b = new Byte[OSPFv2Fields.LSAHeaderPosition];
             Array.Copy(header.Bytes, b, header.Bytes.Length);
             this.header = new ByteArraySegment(b, 0, OSPFv2Fields.LSAHeaderPosition);
             this.Type = packetType;
 
-            this.PacketLength = (ushort)header.Bytes.Length;
+            this.PacketLength = (UInt16)header.Bytes.Length;
         }
 
         /// <summary>
@@ -545,12 +545,12 @@ namespace PacketDotNet
         /// <param name="lsas">List of the LSA headers</param>
         public OSPFv2DDPacket(List<LSA> lsas)
         {
-            int length = lsas.Count * OSPFv2Fields.LSAHeaderLength;
-            int offset = OSPFv2Fields.LSAHeaderPosition;
-            byte[] bytes = new byte[length + OSPFv2Fields.LSAHeaderPosition];
+            Int32 length = lsas.Count * OSPFv2Fields.LSAHeaderLength;
+            Int32 offset = OSPFv2Fields.LSAHeaderPosition;
+            Byte[] bytes = new Byte[length + OSPFv2Fields.LSAHeaderPosition];
 
             Array.Copy(header.Bytes, bytes, header.Length);
-            for (int i = 0; i < lsas.Count; i++)
+            for (Int32 i = 0; i < lsas.Count; i++)
             {
                 Array.Copy(lsas[i].Bytes, 0, bytes, offset, 20); //20 bytes per header
                 offset += 20;
@@ -558,7 +558,7 @@ namespace PacketDotNet
 
             header = new ByteArraySegment(bytes);
             this.Type = packetType;
-            this.PacketLength = (ushort)header.Bytes.Length;
+            this.PacketLength = (UInt16)header.Bytes.Length;
         }
 
         /// <summary>
@@ -570,7 +570,7 @@ namespace PacketDotNet
         /// <param name="Offset">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public OSPFv2DDPacket(byte[] Bytes, int Offset) :
+        public OSPFv2DDPacket(Byte[] Bytes, Int32 Offset) :
             base(Bytes, Offset)
         {
             this.Type = packetType;
@@ -581,7 +581,7 @@ namespace PacketDotNet
         /// The size in bytes of the largest IP datagram that can be sent
         /// out the associated interface, without fragmentation.
         /// </summary>
-        public virtual ushort InterfaceMTU
+        public virtual UInt16 InterfaceMTU
         {
             get
             {
@@ -596,7 +596,7 @@ namespace PacketDotNet
         /// <summary>
         /// The optional capabilities supported by the router. See http://www.ietf.org/rfc/rfc2328.txt for details.
         /// </summary>
-        public virtual byte DBDescriptionOptions
+        public virtual Byte DBDescriptionOptions
         {
             get
             {
@@ -612,7 +612,7 @@ namespace PacketDotNet
         /// <summary>
         /// DD Packet bits - See http://www.ietf.org/rfc/rfc2328.txt for details.
         /// </summary>
-        public virtual byte DBDescriptionBits
+        public virtual Byte DBDescriptionBits
         {
             get
             {
@@ -627,7 +627,7 @@ namespace PacketDotNet
         /// <summary>
         /// Used to sequence the collection of Database Description Packets.
         /// </summary>
-        public virtual uint DDSequence
+        public virtual UInt32 DDSequence
         {
             get
             {
@@ -650,17 +650,17 @@ namespace PacketDotNet
             get
             {
                 List<LSA> ret = new List<LSA>();
-                int bytesNeeded = this.PacketLength - OSPFv2Fields.LSAHeaderPosition;
+                Int32 bytesNeeded = this.PacketLength - OSPFv2Fields.LSAHeaderPosition;
 
                 if (bytesNeeded % OSPFv2Fields.LSAHeaderLength != 0)
                 {
                     throw new Exception("OSPFv2 DD Packet - Invalid LSA headers count");
                 }
 
-                int offset = this.header.Offset + OSPFv2Fields.LSAHeaderPosition;
-                int headerCount = bytesNeeded / OSPFv2Fields.LSAHeaderLength;
+                Int32 offset = this.header.Offset + OSPFv2Fields.LSAHeaderPosition;
+                Int32 headerCount = bytesNeeded / OSPFv2Fields.LSAHeaderLength;
 
-                for (int i = 0; i < headerCount; i++)
+                for (Int32 i = 0; i < headerCount; i++)
                 {
                     LSA l = new LSA(this.header.Bytes, offset , OSPFv2Fields.LSAHeaderLength);
                     offset += OSPFv2Fields.LSAHeaderLength;
@@ -674,7 +674,7 @@ namespace PacketDotNet
         /// Returns a <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2DDPacket"/>.
         /// </summary>
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2DDPacket"/>.</returns>
-        public override string ToString()
+        public override String ToString()
         {
             StringBuilder packet = new StringBuilder();
             packet.Append(base.ToString());
@@ -693,7 +693,7 @@ namespace PacketDotNet
         /// </summary>
         /// <returns>The string.</returns>
         /// <param name="outputFormat">Output format.</param>
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             return ToString();
         }
@@ -718,7 +718,7 @@ namespace PacketDotNet
         public OSPFv2LSRequestPacket()
         {
             this.Type = packetType;
-            this.PacketLength = (ushort)header.Bytes.Length;
+            this.PacketLength = (UInt16)header.Bytes.Length;
         }
 
         /// <summary>
@@ -727,12 +727,12 @@ namespace PacketDotNet
         /// <param name="lsrs">List of the link state requests</param>
         public OSPFv2LSRequestPacket(List<LinkStateRequest> lsrs)
         {
-            int length = lsrs.Count * LinkStateRequest.Length;
-            int offset = OSPFv2Fields.HeaderLength;
-            byte[] bytes = new byte[length + OSPFv2Fields.HeaderLength];
+            Int32 length = lsrs.Count * LinkStateRequest.Length;
+            Int32 offset = OSPFv2Fields.HeaderLength;
+            Byte[] bytes = new Byte[length + OSPFv2Fields.HeaderLength];
 
             Array.Copy(header.Bytes, bytes, header.Length);
-            for (int i = 0; i < lsrs.Count; i++)
+            for (Int32 i = 0; i < lsrs.Count; i++)
             {
                 Array.Copy(lsrs[i].Bytes, 0, bytes, offset, LinkStateRequest.Length);
                 offset += LinkStateRequest.Length;
@@ -740,7 +740,7 @@ namespace PacketDotNet
 
             header = new ByteArraySegment(bytes);
             this.Type = packetType;
-            this.PacketLength = (ushort)header.Bytes.Length;
+            this.PacketLength = (UInt16)header.Bytes.Length;
         }
 
         /// <summary>
@@ -763,7 +763,7 @@ namespace PacketDotNet
         /// <param name="Offset">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public OSPFv2LSRequestPacket(byte[] Bytes, int Offset) :
+        public OSPFv2LSRequestPacket(Byte[] Bytes, Int32 Offset) :
             base(Bytes, Offset)
         {
             this.Type = packetType;
@@ -777,17 +777,17 @@ namespace PacketDotNet
         {
             get
             {
-                int bytesNeeded = this.PacketLength - OSPFv2Fields.LSRStart;
+                Int32 bytesNeeded = this.PacketLength - OSPFv2Fields.LSRStart;
                 if (bytesNeeded % LinkStateRequest.Length != 0)
                 {
                     throw new Exception("Malformed LSR packet - bad size for the LS requests");
                 }
 
                 List<LinkStateRequest> ret = new List<LinkStateRequest>();
-                int offset = this.header.Offset + OSPFv2Fields.LSRStart;
-                int lsrCount = bytesNeeded / LinkStateRequest.Length;
+                Int32 offset = this.header.Offset + OSPFv2Fields.LSRStart;
+                Int32 lsrCount = bytesNeeded / LinkStateRequest.Length;
 
-                for (int i = 0; i < lsrCount; i++)
+                for (Int32 i = 0; i < lsrCount; i++)
                 {
                     LinkStateRequest request = new LinkStateRequest(this.header.Bytes, offset, LinkStateRequest.Length);
                     ret.Add(request);
@@ -801,7 +801,7 @@ namespace PacketDotNet
         /// Returns a <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2LSRequestPacket"/>.
         /// </summary>
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2LSRequestPacket"/>.</returns>
-        public override string ToString()
+        public override String ToString()
         {
             StringBuilder packet = new StringBuilder();
             packet.Append(base.ToString());
@@ -819,7 +819,7 @@ namespace PacketDotNet
         /// </summary>
         /// <returns>The string.</returns>
         /// <param name="outputFormat">Output format.</param>
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             return ToString();
         }
@@ -841,12 +841,12 @@ namespace PacketDotNet
         /// </summary>
         public OSPFv2LSUpdatePacket()
         {
-            byte[] b = new byte[OSPFv2Fields.HeaderLength + 4];
+            Byte[] b = new Byte[OSPFv2Fields.HeaderLength + 4];
             Array.Copy(header.Bytes, b, header.Bytes.Length);
             this.header = new ByteArraySegment(b, 0, OSPFv2Fields.LSRStart);
             this.Type = packetType;
 
-            this.PacketLength = (ushort)header.Bytes.Length;
+            this.PacketLength = (UInt16)header.Bytes.Length;
             this.LSANumber = 0;
         }
 
@@ -856,19 +856,19 @@ namespace PacketDotNet
         /// <param name="lsas">List of the LSA headers</param>
         public OSPFv2LSUpdatePacket(List<LSA> lsas)
         {
-            int length = 0;
-            int offset = OSPFv2Fields.HeaderLength + OSPFv2Fields.LSANumberLength;
+            Int32 length = 0;
+            Int32 offset = OSPFv2Fields.HeaderLength + OSPFv2Fields.LSANumberLength;
 
             //calculate the length for the LSAs
-            for (int i = 0; i < lsas.Count; i++)
+            for (Int32 i = 0; i < lsas.Count; i++)
             {
                 length += lsas[i].Bytes.Length;
             }
 
-            byte[] bytes = new byte[length + offset];
+            Byte[] bytes = new Byte[length + offset];
 
             Array.Copy(header.Bytes, bytes, header.Length);
-            for (int i = 0; i < lsas.Count; i++)
+            for (Int32 i = 0; i < lsas.Count; i++)
             {
                 Array.Copy(lsas[i].Bytes, 0, bytes, offset, lsas[i].Bytes.Length);
                 offset += lsas[i].Bytes.Length;
@@ -876,8 +876,8 @@ namespace PacketDotNet
 
             header = new ByteArraySegment(bytes);
             this.Type = packetType;
-            this.PacketLength = (ushort)header.Bytes.Length;
-            this.LSANumber = (uint)lsas.Count;
+            this.PacketLength = (UInt16)header.Bytes.Length;
+            this.LSANumber = (UInt32)lsas.Count;
         }
 
         /// <summary>
@@ -889,7 +889,7 @@ namespace PacketDotNet
         /// <param name="Offset">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public OSPFv2LSUpdatePacket(byte[] Bytes, int Offset) :
+        public OSPFv2LSUpdatePacket(Byte[] Bytes, Int32 Offset) :
             base(Bytes, Offset)
         {
             this.Type = packetType;
@@ -909,7 +909,7 @@ namespace PacketDotNet
         /// <summary>
         /// The number of LSAs included in this update.
         /// </summary>
-        public virtual uint LSANumber
+        public virtual UInt32 LSANumber
         {
             get
             {
@@ -931,8 +931,8 @@ namespace PacketDotNet
             {
                 List<LSA> ret = new List<LSA>();
 
-                int offset = this.header.Offset + OSPFv2Fields.LSAUpdatesPositon;
-                for (int i = 0; i < this.LSANumber; i++)
+                Int32 offset = this.header.Offset + OSPFv2Fields.LSAUpdatesPositon;
+                for (Int32 i = 0; i < this.LSANumber; i++)
                 {
                     LSA l = new LSA(this.header.Bytes, offset, OSPFv2Fields.LSAHeaderLength);
                     switch (l.LSType)
@@ -961,7 +961,7 @@ namespace PacketDotNet
         /// Returns a <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2LSUpdatePacket"/>.
         /// </summary>
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2LSUpdatePacket"/>.</returns>
-        public override string ToString()
+        public override String ToString()
         {
             StringBuilder packet = new StringBuilder();
             packet.Append(base.ToString());
@@ -979,7 +979,7 @@ namespace PacketDotNet
         /// </summary>
         /// <returns>The string.</returns>
         /// <param name="outputFormat">Output format.</param>
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             return ToString();
         }
@@ -1013,12 +1013,12 @@ namespace PacketDotNet
         /// </summary>
         public OSPFv2LSAPacket()
         {
-            byte[] b = new byte[OSPFv2Fields.LSAHeaderPosition];
+            Byte[] b = new Byte[OSPFv2Fields.LSAHeaderPosition];
             Array.Copy(header.Bytes, b, header.Bytes.Length);
             this.header = new ByteArraySegment(b, 0, OSPFv2Fields.LSAHeaderPosition);
             this.Type = packetType;
 
-            this.PacketLength = (ushort)header.Bytes.Length;
+            this.PacketLength = (UInt16)header.Bytes.Length;
         }
 
         /// <summary>
@@ -1027,12 +1027,12 @@ namespace PacketDotNet
         /// <param name="lsas">List of the LSA headers</param>
         public OSPFv2LSAPacket(List<LSA> lsas)
         {
-            int length = lsas.Count * OSPFv2Fields.LSAHeaderLength;
-            int offset = OSPFv2Fields.HeaderLength;
-            byte[] bytes = new byte[length + OSPFv2Fields.HeaderLength];
+            Int32 length = lsas.Count * OSPFv2Fields.LSAHeaderLength;
+            Int32 offset = OSPFv2Fields.HeaderLength;
+            Byte[] bytes = new Byte[length + OSPFv2Fields.HeaderLength];
 
             Array.Copy(header.Bytes, bytes, header.Length);
-            for (int i = 0; i < lsas.Count; i++)
+            for (Int32 i = 0; i < lsas.Count; i++)
             {
                 Array.Copy(lsas[i].Bytes, 0, bytes, offset, OSPFv2Fields.LSAHeaderLength); 
                 offset += 20;
@@ -1040,7 +1040,7 @@ namespace PacketDotNet
 
             header = new ByteArraySegment(bytes);
             this.Type = packetType;
-            this.PacketLength = (ushort)header.Bytes.Length;
+            this.PacketLength = (UInt16)header.Bytes.Length;
         }
 
         /// <summary>
@@ -1052,7 +1052,7 @@ namespace PacketDotNet
         /// <param name="Offset">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public OSPFv2LSAPacket(byte[] Bytes, int Offset) :
+        public OSPFv2LSAPacket(Byte[] Bytes, Int32 Offset) :
             base(Bytes, Offset)
         {
             this.Type = packetType;
@@ -1066,17 +1066,17 @@ namespace PacketDotNet
             get
             {
                 List<LSA> ret = new List<LSA>();
-                int bytesNeeded = this.PacketLength - OSPFv2Fields.LSAAckPosition;
+                Int32 bytesNeeded = this.PacketLength - OSPFv2Fields.LSAAckPosition;
 
                 if (bytesNeeded % OSPFv2Fields.LSAHeaderLength != 0)
                 {
                     throw new Exception("OSPFv2 LSA Packet - Invalid LSA headers count");
                 }
 
-                int offset = this.header.Offset + OSPFv2Fields.LSAAckPosition;
-                int headerCount = bytesNeeded / OSPFv2Fields.LSAHeaderLength;
+                Int32 offset = this.header.Offset + OSPFv2Fields.LSAAckPosition;
+                Int32 headerCount = bytesNeeded / OSPFv2Fields.LSAHeaderLength;
 
-                for (int i = 0; i < headerCount; i++)
+                for (Int32 i = 0; i < headerCount; i++)
                 {
                     LSA l = new LSA(this.header.Bytes, offset, OSPFv2Fields.LSAHeaderLength);
                     ret.Add(l);
@@ -1090,7 +1090,7 @@ namespace PacketDotNet
         /// Returns a <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2LSAPacket"/>.
         /// </summary>
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="PacketDotNet.OSPFv2LSAPacket"/>.</returns>
-        public override string ToString()
+        public override String ToString()
         {
             StringBuilder packet = new StringBuilder();
             packet.Append(base.ToString());
@@ -1107,7 +1107,7 @@ namespace PacketDotNet
         /// </summary>
         /// <returns>The string.</returns>
         /// <param name="outputFormat">Output format.</param>
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             return ToString();
         }

--- a/PacketDotNet/PPPFields.cs
+++ b/PacketDotNet/PPPFields.cs
@@ -30,16 +30,16 @@ namespace PacketDotNet
         /// Length of the Protocol field in bytes, the field is of type
         /// PPPProtocol
         /// </summary>
-        public static readonly int ProtocolLength = 2;
+        public static readonly Int32 ProtocolLength = 2;
 
         /// <summary>
         /// Offset from the start of the PPP packet where the Protocol field is located
         /// </summary>
-        public static readonly int ProtocolPosition = 0;
+        public static readonly Int32 ProtocolPosition = 0;
 
         /// <summary>
         /// The length of the header
         /// </summary>
-        public static readonly int HeaderLength = ProtocolLength;
+        public static readonly Int32 HeaderLength = ProtocolLength;
     }
 }

--- a/PacketDotNet/PPPPacket.cs
+++ b/PacketDotNet/PPPPacket.cs
@@ -71,9 +71,9 @@ namespace PacketDotNet
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int length = PPPFields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = PPPFields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             // setup some typical values and default values
@@ -135,11 +135,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -159,11 +159,11 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("protocol", Protocol.ToString() + " (0x" + Protocol.ToString("x") + ")");
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("PPP:  ******* PPP - \"Point-to-Point Protocol\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/PPPoEFields.cs
+++ b/PacketDotNet/PPPoEFields.cs
@@ -28,33 +28,33 @@ namespace PacketDotNet
     public class PPPoEFields
     {
         /// <summary> Size in bytes of the version/type field </summary>
-        public readonly static int VersionTypeLength = 1;
+        public readonly static Int32 VersionTypeLength = 1;
 
         /// <summary> Size in bytes of the code field </summary>
-        public readonly static int CodeLength = 1;
+        public readonly static Int32 CodeLength = 1;
 
         /// <summary> Size in bytes of the SessionId field </summary>
-        public readonly static int SessionIdLength = 2;
+        public readonly static Int32 SessionIdLength = 2;
 
         /// <summary> Size in bytes of the Length field </summary>
-        public readonly static int LengthLength = 2;
+        public readonly static Int32 LengthLength = 2;
 
         /// <summary> Offset from the start of the header to the version/type field </summary>
-        public readonly static int VersionTypePosition = 0;
+        public readonly static Int32 VersionTypePosition = 0;
 
         /// <summary> Offset from the start of the header to the Code field </summary>
-        public readonly static int CodePosition;
+        public readonly static Int32 CodePosition;
 
         /// <summary> Offset from the start of the header to the SessionId field </summary>
-        public readonly static int SessionIdPosition;
+        public readonly static Int32 SessionIdPosition;
 
         /// <summary> Offset from the start of the header to the Length field </summary>
-        public readonly static int LengthPosition;
+        public readonly static Int32 LengthPosition;
 
         /// <summary>
         /// Length of the overall PPPoe header
         /// </summary>
-        public readonly static int HeaderLength;
+        public readonly static Int32 HeaderLength;
 
         static PPPoEFields()
         {

--- a/PacketDotNet/PPPoEPacket.cs
+++ b/PacketDotNet/PPPoEPacket.cs
@@ -41,7 +41,7 @@ namespace PacketDotNet
 #pragma warning restore 0169, 0649
 #endif
 
-        private byte VersionType
+        private Byte VersionType
         {
             get
             {
@@ -58,11 +58,11 @@ namespace PacketDotNet
         /// PPPoe version, must be 0x1 according to RFC
         /// </summary>
         /// FIXME: This currently outputs the wrong version number
-        public byte Version
+        public Byte Version
         {
             get
             {
-                return (byte)((VersionType >> 4) & 0xF0);
+                return (Byte)((VersionType >> 4) & 0xF0);
             }
 
             set
@@ -70,7 +70,7 @@ namespace PacketDotNet
                 var versionType = VersionType;
 
                 // mask the new value in
-                versionType = (byte)((versionType & 0x0F) | ((value << 4) & 0xF0));
+                versionType = (Byte)((versionType & 0x0F) | ((value << 4) & 0xF0));
 
                 VersionType = versionType;
             }
@@ -79,11 +79,11 @@ namespace PacketDotNet
         /// <summary>
         /// Type, must be 0x1 according to RFC
         /// </summary>
-        public byte Type
+        public Byte Type
         {
             get
             {
-                return (byte)((VersionType) & 0x0F);
+                return (Byte)((VersionType) & 0x0F);
             }
 
             set
@@ -91,7 +91,7 @@ namespace PacketDotNet
                 var versionType = VersionType;
 
                 // mask the new value in
-                versionType = (byte)((versionType & 0xF0) | (value & 0xF0));
+                versionType = (Byte)((versionType & 0xF0) | (value & 0xF0));
 
                 VersionType = versionType;
             }
@@ -167,9 +167,9 @@ namespace PacketDotNet
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int length = PPPoEFields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = PPPoEFields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             // set the instance values
@@ -224,11 +224,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -252,7 +252,7 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 // FIXME: The version output is incorrect
                 properties.Add("", Convert.ToString(Version, 2).PadLeft(4, '0') + " .... = version: " + Version.ToString());
                 properties.Add(" ", ".... " + Convert.ToString(Type, 2).PadLeft(4, '0') + " = type: " + Type.ToString());
@@ -263,7 +263,7 @@ namespace PacketDotNet
                 //properties.Add("payload length", PayloadLength.ToString());
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("PPPoE:  ******* PPPoE - \"Point-to-Point Protocol over Ethernet\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/Packet.cs
+++ b/PacketDotNet/Packet.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
 PacketDotNet is free software: you can redistribute it and/or modify
@@ -18,7 +18,7 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
 
-﻿using System;
+ using System;
 using System.IO;
 using System.Text;
 using PacketDotNet.Utils;
@@ -66,11 +66,11 @@ namespace PacketDotNet
         /// <value>
         /// The total length of the packet.
         /// </value>
-        protected int TotalPacketLength
+        protected Int32 TotalPacketLength
         {
             get
             {
-                int totalLength = 0;
+                Int32 totalLength = 0;
                 totalLength += header.Length;
 
                 if(payloadPacketOrData.Type == PayloadType.Bytes)
@@ -95,7 +95,7 @@ namespace PacketDotNet
         /// are the same instance and the offsets indicate that the bytes
         /// are contiguous
         /// </value>
-        protected bool SharesMemoryWithSubPackets
+        protected Boolean SharesMemoryWithSubPackets
         {
             get
             {
@@ -154,7 +154,7 @@ namespace PacketDotNet
         /// <value>
         /// Returns a
         /// </value>
-        public virtual byte[] Header
+        public virtual Byte[] Header
         {
             get { return this.header.ActualBytes(); }
         }
@@ -182,7 +182,7 @@ namespace PacketDotNet
         /// Note that the packet MAY have a null PayloadData but a
         /// non-null PayloadPacket
         /// </summary>
-        public byte[] PayloadData
+        public Byte[] PayloadData
         {
             get
             {
@@ -210,7 +210,7 @@ namespace PacketDotNet
         /// byte[] containing this packet and its payload
         /// NOTE: Use 'public virtual ByteArraySegment BytesHighPerformance' for highest performance
         /// </summary>
-        public virtual byte[] Bytes
+        public virtual Byte[] Bytes
         {
             get
             {
@@ -293,7 +293,7 @@ namespace PacketDotNet
         /// A <see cref="Packet"/>
         /// </returns>
         public static Packet ParsePacket(LinkLayers LinkLayer,
-                                         byte[] PacketData)
+                                         Byte[] PacketData)
         {
             Packet p;
             var bas = new ByteArraySegment(PacketData);
@@ -377,7 +377,7 @@ namespace PacketDotNet
         /// <param name="outputFormat">
         /// <see cref="StringOutputType" />
         /// </param>
-        public virtual string ToString(StringOutputType outputFormat)
+        public virtual String ToString(StringOutputType outputFormat)
         {
             if(payloadPacketOrData.Type == PayloadType.Packet)
             {
@@ -397,20 +397,20 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public string PrintHex()
+        public String PrintHex()
         {
-            byte[] data = BytesHighPerformance.Bytes;
+            Byte[] data = BytesHighPerformance.Bytes;
             var buffer = new StringBuilder();
-            string segmentNumber = "";
-            string bytes = "";
-            string ascii = "";
+            String segmentNumber = "";
+            String bytes = "";
+            String ascii = "";
 
             buffer.AppendLine("Data:  ******* Raw Hex Output - length=" + data.Length + " bytes");
             buffer.AppendLine("Data: Segment:                   Bytes:                              Ascii:");
             buffer.AppendLine("Data: --------------------------------------------------------------------------");
 
             // parse the raw data
-            for(int i = 1; i <= data.Length; i++)
+            for(Int32 i = 1; i <= data.Length; i++)
             {
                 // add the current byte to the bytes hex string
                 bytes += (data[i-1].ToString("x")).PadLeft(2, '0') + " ";
@@ -422,7 +422,7 @@ namespace PacketDotNet
                 }
                 else
                 {
-                    ascii += Encoding.ASCII.GetString(new byte[1] { data[i-1] });
+                    ascii += Encoding.ASCII.GetString(new Byte[1] { data[i-1] });
                 }
 
                 // add an additional space to split the bytes into

--- a/PacketDotNet/RawIPPacket.cs
+++ b/PacketDotNet/RawIPPacket.cs
@@ -84,11 +84,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if (outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -108,11 +108,11 @@ namespace PacketDotNet
             if (outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string, string> properties = new Dictionary<string, string>();
+                Dictionary<String, String> properties = new Dictionary<String, String>();
                 properties.Add("protocol", Protocol.ToString() + " (0x" + Protocol.ToString("x") + ")");
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("Raw:  ******* Raw - \"Raw IP Packet\" - offset=? length=" + TotalPacketLength);

--- a/PacketDotNet/Tcp/AlternateChecksumData.cs
+++ b/PacketDotNet/Tcp/AlternateChecksumData.cs
@@ -48,7 +48,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public AlternateChecksumData(byte[] bytes, int offset, int length) :
+        public AlternateChecksumData(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -59,11 +59,11 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The array of attached Checksum
         /// </summary>
-        public byte[] Data
+        public Byte[] Data
         {
             get
             {
-                byte[] data = new byte[Length - DataFieldOffset];
+                Byte[] data = new Byte[Length - DataFieldOffset];
                 Array.Copy(Bytes, DataFieldOffset, data, 0, data.Length);
                 return data;
             }
@@ -79,7 +79,7 @@ namespace PacketDotNet.Tcp
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString()
+        public override String ToString()
         {
             return "[" + Kind.ToString() + ": Data=0x" + Data.ToString() + "]";
         }
@@ -89,7 +89,7 @@ namespace PacketDotNet.Tcp
         #region Members
 
         // the offset (in bytes) of the Data Field
-        const int DataFieldOffset = 2;
+        const Int32 DataFieldOffset = 2;
 
         #endregion
     }

--- a/PacketDotNet/Tcp/AlternateChecksumRequest.cs
+++ b/PacketDotNet/Tcp/AlternateChecksumRequest.cs
@@ -47,7 +47,7 @@ namespace PacketDotNet.Tcp
         /// References:
         ///  http://datatracker.ietf.org/doc/rfc1146/
         /// </remarks>
-         public AlternateChecksumRequest(byte[] bytes, int offset, int length) :
+         public AlternateChecksumRequest(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -73,7 +73,7 @@ namespace PacketDotNet.Tcp
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString()
+        public override String ToString()
         {
             return "[" + Kind.ToString() + ": ChecksumType=" + Checksum.ToString() + "]";
         }
@@ -83,7 +83,7 @@ namespace PacketDotNet.Tcp
         #region Members
 
         // the offset (in bytes) of the Checksum field
-        const int ChecksumFieldOffset = 2;
+        const Int32 ChecksumFieldOffset = 2;
 
         #endregion
     }

--- a/PacketDotNet/Tcp/Echo.cs
+++ b/PacketDotNet/Tcp/Echo.cs
@@ -42,7 +42,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public Echo(byte[] bytes, int offset, int length) :
+        public Echo(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         {
             throw new NotSupportedException("Obsolete: The Echo Option has been deprecated.");

--- a/PacketDotNet/Tcp/EchoReply.cs
+++ b/PacketDotNet/Tcp/EchoReply.cs
@@ -46,7 +46,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public EchoReply(byte[] bytes, int offset, int length):
+        public EchoReply(Byte[] bytes, Int32 offset, Int32 length):
             base(bytes, offset, length)
         {
             throw new NotSupportedException("Obsolete: The Echo Option has been deprecated.");

--- a/PacketDotNet/Tcp/EndOfOptions.cs
+++ b/PacketDotNet/Tcp/EndOfOptions.cs
@@ -45,7 +45,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public EndOfOptions(byte[] bytes, int offset, int length) :
+        public EndOfOptions(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -59,7 +59,7 @@ namespace PacketDotNet.Tcp
         ///  the EndOfOptions option is only 1 byte long and doesn't
         ///  contain a length field
         /// </summary>
-        public override byte Length
+        public override Byte Length
         {
             get { return EndOfOptions.OptionLength; }
         }
@@ -71,7 +71,7 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The length (in bytes) of the EndOfOptions option
         /// </summary>
-        internal const int OptionLength = 1;
+        internal const Int32 OptionLength = 1;
 
         #endregion
     }

--- a/PacketDotNet/Tcp/MD5Signature.cs
+++ b/PacketDotNet/Tcp/MD5Signature.cs
@@ -48,7 +48,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public MD5Signature(byte[] bytes, int offset, int length) :
+        public MD5Signature(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -59,11 +59,11 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The MD5 Digest
         /// </summary>
-        public byte[] MD5Digest
+        public Byte[] MD5Digest
         {
             get
             {
-                byte[] data = new byte[Length - MD5DigestFieldOffset];
+                Byte[] data = new Byte[Length - MD5DigestFieldOffset];
                 Array.Copy(Bytes, MD5DigestFieldOffset, data, 0, data.Length);
                 return data;
             }
@@ -79,7 +79,7 @@ namespace PacketDotNet.Tcp
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString()
+        public override String ToString()
         {
             return "[" + Kind.ToString() + ": MD5Digest=0x" + MD5Digest.ToString() + "]";
         }
@@ -89,7 +89,7 @@ namespace PacketDotNet.Tcp
         #region Members
 
         // the offset (in bytes) of the MD5 Digest field
-        const int MD5DigestFieldOffset = 2;
+        const Int32 MD5DigestFieldOffset = 2;
 
         #endregion
     }

--- a/PacketDotNet/Tcp/MaximumSegmentSize.cs
+++ b/PacketDotNet/Tcp/MaximumSegmentSize.cs
@@ -48,7 +48,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public MaximumSegmentSize(byte[] bytes, int offset, int length) :
+        public MaximumSegmentSize(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -59,7 +59,7 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The Maximum Segment Size
         /// </summary>
-        public ushort Value
+        public UInt16 Value
         {
             get { return EndianBitConverter.Big.ToUInt16(Bytes, ValueFieldOffset); }
         }
@@ -74,7 +74,7 @@ namespace PacketDotNet.Tcp
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString()
+        public override String ToString()
         {
             return "[" + Kind.ToString() + ": Value=" + Value.ToString() + " bytes]";
         }
@@ -84,7 +84,7 @@ namespace PacketDotNet.Tcp
          #region Members
 
         // the offset (in bytes) of the Value Field
-        const int ValueFieldOffset = 2;
+        const Int32 ValueFieldOffset = 2;
 
         #endregion
     }

--- a/PacketDotNet/Tcp/NoOperation.cs
+++ b/PacketDotNet/Tcp/NoOperation.cs
@@ -45,7 +45,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public NoOperation(byte[] bytes, int offset, int length) :
+        public NoOperation(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -59,7 +59,7 @@ namespace PacketDotNet.Tcp
         ///  the NoOperation option is only 1 byte long and doesn't
         ///  contain a length field
         /// </summary>
-        public override byte Length
+        public override Byte Length
         {
             get { return NoOperation.OptionLength; }
         }
@@ -71,7 +71,7 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The length (in bytes) of the NoOperation option
         /// </summary>
-        internal const int OptionLength = 1;
+        internal const Int32 OptionLength = 1;
 
         #endregion
     }

--- a/PacketDotNet/Tcp/Option.cs
+++ b/PacketDotNet/Tcp/Option.cs
@@ -41,7 +41,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public Option(byte[] bytes, int offset, int length)
+        public Option(Byte[] bytes, Int32 offset, Int32 length)
         {
             optionData = new ByteArraySegment(bytes, offset, length);
         }
@@ -53,7 +53,7 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The Length of the Option type
         /// </summary>
-        public virtual byte Length
+        public virtual Byte Length
         {
             get { return Bytes[LengthFieldOffset]; }
         }
@@ -69,11 +69,11 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// Returns a TLV that contains the Option
         /// </summary>
-        public byte[] Bytes
+        public Byte[] Bytes
         {
             get
             {
-                byte[] bytes = new byte[optionData.Length];
+                Byte[] bytes = new Byte[optionData.Length];
                 Array.Copy(optionData.Bytes, optionData.Offset, bytes, 0, optionData.Length);
                 return  bytes;
             }
@@ -89,7 +89,7 @@ namespace PacketDotNet.Tcp
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString()
+        public override String ToString()
         {
             return "[" + Kind.ToString() + "]";
         }
@@ -102,16 +102,16 @@ namespace PacketDotNet.Tcp
         private ByteArraySegment optionData;
 
         /// <summary>The length (in bytes) of the Kind field</summary>
-        internal const int KindFieldLength = 1;
+        internal const Int32 KindFieldLength = 1;
 
         /// <summary>The length (in bytes) of the Length field</summary>
-        internal const int LengthFieldLength = 1;
+        internal const Int32 LengthFieldLength = 1;
 
         /// <summary>The offset (in bytes) of the Kind Field</summary>
-        internal const int KindFieldOffset = 0;
+        internal const Int32 KindFieldOffset = 0;
 
         /// <summary>The offset (in bytes) of the Length field</summary>
-        internal const int LengthFieldOffset = 1;
+        internal const Int32 LengthFieldOffset = 1;
 
         #endregion
     }

--- a/PacketDotNet/Tcp/SACK.cs
+++ b/PacketDotNet/Tcp/SACK.cs
@@ -50,7 +50,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public SACK(byte[] bytes, int offset, int length) :
+        public SACK(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -61,14 +61,14 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// Contains an array of SACK (Selective Ack) Blocks
         /// </summary>
-        public ushort[] SACKBlocks
+        public UInt16[] SACKBlocks
         {
             get
             {
-                int numOfBlocks = (Length - SACKBlocksFieldOffset) / BlockLength;
-                ushort[] blocks = new ushort[numOfBlocks];
-                int offset = 0;
-                for(int i = 0; i < numOfBlocks; i++)
+                Int32 numOfBlocks = (Length - SACKBlocksFieldOffset) / BlockLength;
+                UInt16[] blocks = new UInt16[numOfBlocks];
+                Int32 offset = 0;
+                for(Int32 i = 0; i < numOfBlocks; i++)
                 {
                     offset = SACKBlocksFieldOffset + (i * BlockLength);
                     blocks[i] = EndianBitConverter.Big.ToUInt16(Bytes, offset);
@@ -87,11 +87,11 @@ namespace PacketDotNet.Tcp
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString()
+        public override String ToString()
         {
-            string output = "[" + Kind.ToString() + ": ";
+            String output = "[" + Kind.ToString() + ": ";
 
-            for(int i = 0; i < SACKBlocks.Length; i++)
+            for(Int32 i = 0; i < SACKBlocks.Length; i++)
             {
                 output += "Block" + i + "=" + SACKBlocks[i].ToString() + " ";
             }
@@ -107,10 +107,10 @@ namespace PacketDotNet.Tcp
         #region Members
 
         // the length (in bytes) of a SACK block
-        const int BlockLength = 2;
+        const Int32 BlockLength = 2;
 
         // the offset (in bytes) of the ScaleFactor Field
-        const int SACKBlocksFieldOffset = 2;
+        const Int32 SACKBlocksFieldOffset = 2;
 
        #endregion
     }

--- a/PacketDotNet/Tcp/SACKPermitted.cs
+++ b/PacketDotNet/Tcp/SACKPermitted.cs
@@ -48,7 +48,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public SACKPermitted(byte[] bytes, int offset, int length) :
+        public SACKPermitted(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 

--- a/PacketDotNet/Tcp/TimeStamp.cs
+++ b/PacketDotNet/Tcp/TimeStamp.cs
@@ -50,7 +50,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public TimeStamp(byte[] bytes, int offset, int length) :
+        public TimeStamp(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -61,7 +61,7 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The Timestamp value
         /// </summary>
-        public uint Value
+        public UInt32 Value
         {
             get { return EndianBitConverter.Big.ToUInt32(Bytes, ValueFieldOffset); }
         }
@@ -69,7 +69,7 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The Echo Reply
         /// </summary>
-        public uint EchoReply
+        public UInt32 EchoReply
         {
             get { return EndianBitConverter.Big.ToUInt32(Bytes, EchoReplyFieldOffset); }
         }
@@ -84,7 +84,7 @@ namespace PacketDotNet.Tcp
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString()
+        public override String ToString()
         {
             return "[" + Kind.ToString() + ": Value=" + Value.ToString() + " EchoReply=" + EchoReply.ToString() + "]";
         }
@@ -94,10 +94,10 @@ namespace PacketDotNet.Tcp
         #region Members
 
         // the offset (in bytes) of the Value Field
-        const int ValueFieldOffset = 2;
+        const Int32 ValueFieldOffset = 2;
 
         // the offset (in bytes) of the Echo Reply Field
-        const int EchoReplyFieldOffset = 6;
+        const Int32 EchoReplyFieldOffset = 6;
 
         #endregion
     }

--- a/PacketDotNet/Tcp/UserTimeout.cs
+++ b/PacketDotNet/Tcp/UserTimeout.cs
@@ -48,7 +48,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public UserTimeout(byte[] bytes, int offset, int length) :
+        public UserTimeout(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -59,11 +59,11 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The Granularity
         /// </summary>
-        public bool Granularity
+        public Boolean Granularity
         {
             get
             {
-                int granularity = ((int)Values >> 15);
+                Int32 granularity = ((Int32)Values >> 15);
                 return (granularity != 0);
             }
         }
@@ -71,13 +71,13 @@ namespace PacketDotNet.Tcp
         /// <summary>
         /// The User Timeout
         /// </summary>
-        public ushort Timeout
+        public UInt16 Timeout
         {
-            get { return (ushort)((int)Values & TimeoutMask); }
+            get { return (UInt16)((Int32)Values & TimeoutMask); }
         }
 
         // a convenient property to grab the value fields for further processing
-        private ushort Values
+        private UInt16 Values
         {
             get { return EndianBitConverter.Big.ToUInt16(Bytes, ValuesFieldOffset); }
         }
@@ -91,7 +91,7 @@ namespace PacketDotNet.Tcp
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString()
+        public override String ToString()
         {
             return "[" + Kind.ToString() + ": Granularity=" + (Granularity ? "minutes" : "seconds") + " Timeout=" + Timeout + "]";
         }
@@ -101,11 +101,11 @@ namespace PacketDotNet.Tcp
          #region Members
 
         // the offset (in bytes) of the Value Fields
-        const int ValuesFieldOffset = 2;
+        const Int32 ValuesFieldOffset = 2;
 
         // the mask used to strip the Granularity field from the
         //  Values filed to expose the UserTimeout field
-        const int TimeoutMask = 0x7FFF;
+        const Int32 TimeoutMask = 0x7FFF;
 
         #endregion
     }

--- a/PacketDotNet/Tcp/WindowScaleFactor.cs
+++ b/PacketDotNet/Tcp/WindowScaleFactor.cs
@@ -47,7 +47,7 @@ namespace PacketDotNet.Tcp
         /// <param name="length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public WindowScaleFactor(byte[] bytes, int offset, int length) :
+        public WindowScaleFactor(Byte[] bytes, Int32 offset, Int32 length) :
             base(bytes, offset, length)
         { }
 
@@ -61,7 +61,7 @@ namespace PacketDotNet.Tcp
         ///  The multiplier is equal to 1 left-shifted by the ScaleFactor
         ///  So a scale factor of 7 would equal 1 &lt;&lt; 7 = 128
         /// </summary>
-        public byte ScaleFactor
+        public Byte ScaleFactor
         {
             get { return Bytes[ScaleFactorFieldOffset]; }
         }
@@ -77,7 +77,7 @@ namespace PacketDotNet.Tcp
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString()
+        public override String ToString()
         {
             return "[" + Kind.ToString() + ": ScaleFactor=" + ScaleFactor.ToString() + " (multiply by " + (1 << ScaleFactor).ToString() + ")]";
         }
@@ -87,7 +87,7 @@ namespace PacketDotNet.Tcp
         #region Members
 
         // the offset (in bytes) of the ScaleFactor Field
-        const int ScaleFactorFieldOffset = 2;
+        const Int32 ScaleFactorFieldOffset = 2;
 
         #endregion
     }

--- a/PacketDotNet/TcpFields.cs
+++ b/PacketDotNet/TcpFields.cs
@@ -29,52 +29,52 @@ namespace PacketDotNet
     {
 #pragma warning disable 1591
         // flag bitmasks
-        public readonly static int TCP_NS_MASK = 0x0100;
-        public readonly static int TCP_CWR_MASK = 0x0080;
-        public readonly static int TCP_ECN_MASK = 0x0040;
-        public readonly static int TCP_URG_MASK = 0x0020;
-        public readonly static int TCP_ACK_MASK = 0x0010;
-        public readonly static int TCP_PSH_MASK = 0x0008;
-        public readonly static int TCP_RST_MASK = 0x0004;
-        public readonly static int TCP_SYN_MASK = 0x0002;
-        public readonly static int TCP_FIN_MASK = 0x0001;
+        public readonly static Int32 TCP_NS_MASK = 0x0100;
+        public readonly static Int32 TCP_CWR_MASK = 0x0080;
+        public readonly static Int32 TCP_ECN_MASK = 0x0040;
+        public readonly static Int32 TCP_URG_MASK = 0x0020;
+        public readonly static Int32 TCP_ACK_MASK = 0x0010;
+        public readonly static Int32 TCP_PSH_MASK = 0x0008;
+        public readonly static Int32 TCP_RST_MASK = 0x0004;
+        public readonly static Int32 TCP_SYN_MASK = 0x0002;
+        public readonly static Int32 TCP_FIN_MASK = 0x0001;
 #pragma warning restore 1591
 
         /// <summary> Length of a TCP port in bytes.</summary>
-        public readonly static int PortLength = 2;
+        public readonly static Int32 PortLength = 2;
 
         /// <summary> Length of the sequence number in bytes.</summary>
-        public readonly static int SequenceNumberLength = 4;
+        public readonly static Int32 SequenceNumberLength = 4;
         /// <summary> Length of the acknowledgment number in bytes.</summary>
-        public readonly static int AckNumberLength = 4;
+        public readonly static Int32 AckNumberLength = 4;
         /// <summary> Length of the data offset and flags field in bytes.</summary>
-        public readonly static int DataOffsetAndFlagsLength = 2;
+        public readonly static Int32 DataOffsetAndFlagsLength = 2;
         /// <summary> Length of the window size field in bytes.</summary>
-        public readonly static int WindowSizeLength = 2;
+        public readonly static Int32 WindowSizeLength = 2;
         /// <summary> Length of the checksum field in bytes.</summary>
-        public readonly static int ChecksumLength = 2;
+        public readonly static Int32 ChecksumLength = 2;
         /// <summary> Length of the urgent field in bytes.</summary>
-        public readonly static int UrgentPointerLength = 2;
+        public readonly static Int32 UrgentPointerLength = 2;
 
         /// <summary> Position of the source port field.</summary>
-        public readonly static int SourcePortPosition = 0;
+        public readonly static Int32 SourcePortPosition = 0;
         /// <summary> Position of the destination port field.</summary>
-        public readonly static int DestinationPortPosition;
+        public readonly static Int32 DestinationPortPosition;
         /// <summary> Position of the sequence number field.</summary>
-        public readonly static int SequenceNumberPosition;
+        public readonly static Int32 SequenceNumberPosition;
         /// <summary> Position of the acknowledgment number field.</summary>
-        public readonly static int AckNumberPosition;
+        public readonly static Int32 AckNumberPosition;
         /// <summary> Position of the data offset </summary>
-        public readonly static int DataOffsetAndFlagsPosition;
+        public readonly static Int32 DataOffsetAndFlagsPosition;
         /// <summary> Position of the window size field.</summary>
-        public readonly static int WindowSizePosition;
+        public readonly static Int32 WindowSizePosition;
         /// <summary> Position of the checksum field.</summary>
-        public readonly static int ChecksumPosition;
+        public readonly static Int32 ChecksumPosition;
         /// <summary> Position of the urgent pointer field.</summary>
-        public readonly static int UrgentPointerPosition;
+        public readonly static Int32 UrgentPointerPosition;
 
         /// <summary> Length in bytes of a TCP header.</summary>
-        public readonly static int HeaderLength; // == 20
+        public readonly static Int32 HeaderLength; // == 20
 
         static TcpFields()
         {

--- a/PacketDotNet/TcpPacket.cs
+++ b/PacketDotNet/TcpPacket.cs
@@ -47,10 +47,10 @@ namespace PacketDotNet
         /// <value>
         /// 20 bytes is the smallest tcp header
         /// </value>
-        public const int HeaderMinimumLength = 20;
+        public const Int32 HeaderMinimumLength = 20;
 
         /// <summary> Fetch the port number on the source host.</summary>
-        virtual public ushort SourcePort
+        virtual public UInt16 SourcePort
         {
             get
             {
@@ -68,7 +68,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Fetches the port number on the destination host.</summary>
-        virtual public ushort DestinationPort
+        virtual public UInt16 DestinationPort
         {
             get
             {
@@ -86,7 +86,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Fetch the packet sequence number.</summary>
-        public uint SequenceNumber
+        public UInt32 SequenceNumber
         {
             get
             {
@@ -103,7 +103,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Fetch the packet acknowledgment number.</summary>
-        public uint AcknowledgmentNumber
+        public UInt32 AcknowledgmentNumber
         {
             get
             {
@@ -119,7 +119,7 @@ namespace PacketDotNet
             }
         }
 
-        private ushort DataOffsetAndFlags
+        private UInt16 DataOffsetAndFlags
         {
             get
             {
@@ -136,11 +136,11 @@ namespace PacketDotNet
         }
 
         /// <summary> The size of the tcp header in 32bit words </summary>
-        virtual public int DataOffset
+        virtual public Int32 DataOffset
         {
             get
             {
-                var dataOffset = (byte)((DataOffsetAndFlags >> 12) & 0xF);
+                var dataOffset = (Byte)((DataOffsetAndFlags >> 12) & 0xF);
                 return dataOffset;
             }
 
@@ -148,7 +148,7 @@ namespace PacketDotNet
             {
                 var dataOffset = DataOffsetAndFlags;
 
-                dataOffset = (ushort)((dataOffset & 0x0FFF) | ((value << 12) & 0xF000));
+                dataOffset = (UInt16)((dataOffset & 0x0FFF) | ((value << 12) & 0xF000));
 
                 // write the value back
                 DataOffsetAndFlags = dataOffset;
@@ -179,7 +179,7 @@ namespace PacketDotNet
         /// <value>
         /// Tcp checksum field value of type UInt16
         /// </value>
-        override public ushort Checksum
+        override public UInt16 Checksum
         {
             get
             {
@@ -197,7 +197,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Check if the TCP packet is valid, checksum-wise.</summary>
-        public bool ValidChecksum
+        public Boolean ValidChecksum
         {
             get
             {
@@ -213,7 +213,7 @@ namespace PacketDotNet
         /// <value>
         /// True if the tcp checksum is valid
         /// </value>
-        virtual public bool ValidTCPChecksum
+        virtual public Boolean ValidTCPChecksum
         {
             get
             {
@@ -227,32 +227,32 @@ namespace PacketDotNet
         /// <summary>
         /// Flags, 9 bits
         /// </summary>
-        public ushort AllFlags
+        public UInt16 AllFlags
         {
             get
             {
                 var flags = (DataOffsetAndFlags & 0x1FF);
-                return (ushort)flags;
+                return (UInt16)flags;
             }
 
             set
             {
                 var flags = DataOffsetAndFlags;
 
-                flags = (ushort)((flags & 0xFE00) | (value & 0x1FF));
+                flags = (UInt16)((flags & 0xFE00) | (value & 0x1FF));
                 DataOffsetAndFlags = flags;
             }
         }
 
         /// <summary> Check the URG flag, flag indicates if the urgent pointer is valid.</summary>
-        virtual public bool Urg
+        virtual public Boolean Urg
         {
             get { return (AllFlags & TcpFields.TCP_URG_MASK) != 0; }
             set { setFlag(value, TcpFields.TCP_URG_MASK); }
         }
 
         /// <summary> Check the ACK flag, flag indicates if the ack number is valid.</summary>
-        virtual public bool Ack
+        virtual public Boolean Ack
         {
             get { return (AllFlags & TcpFields.TCP_ACK_MASK) != 0; }
             set { setFlag(value, TcpFields.TCP_ACK_MASK); }
@@ -261,7 +261,7 @@ namespace PacketDotNet
         /// <summary> Check the PSH flag, flag indicates the receiver should pass the
         /// data to the application as soon as possible.
         /// </summary>
-        virtual public bool Psh
+        virtual public Boolean Psh
         {
             get { return (AllFlags & TcpFields.TCP_PSH_MASK) != 0; }
             set { setFlag(value, TcpFields.TCP_PSH_MASK); }
@@ -270,7 +270,7 @@ namespace PacketDotNet
         /// <summary> Check the RST flag, flag indicates the session should be reset between
         /// the sender and the receiver.
         /// </summary>
-        virtual public bool Rst
+        virtual public Boolean Rst
         {
             get { return (AllFlags & TcpFields.TCP_RST_MASK) != 0; }
             set { setFlag(value, TcpFields.TCP_RST_MASK); }
@@ -280,14 +280,14 @@ namespace PacketDotNet
         /// be synchronized between the sender and receiver to initiate
         /// a connection.
         /// </summary>
-        virtual public bool Syn
+        virtual public Boolean Syn
         {
             get { return (AllFlags & TcpFields.TCP_SYN_MASK) != 0; }
             set { setFlag(value, TcpFields.TCP_SYN_MASK); }
         }
 
         /// <summary> Check the FIN flag, flag indicates the sender is finished sending.</summary>
-        virtual public bool Fin
+        virtual public Boolean Fin
         {
             get { return (AllFlags & TcpFields.TCP_FIN_MASK) != 0; }
             set { setFlag(value, TcpFields.TCP_FIN_MASK); }
@@ -296,7 +296,7 @@ namespace PacketDotNet
         /// <value>
         /// ECN flag
         /// </value>
-        virtual public bool ECN
+        virtual public Boolean ECN
         {
             get { return (AllFlags & TcpFields.TCP_ECN_MASK) != 0; }
             set { setFlag(value, TcpFields.TCP_ECN_MASK); }
@@ -305,7 +305,7 @@ namespace PacketDotNet
         /// <value>
         /// CWR flag
         /// </value>
-        virtual public bool CWR
+        virtual public Boolean CWR
         {
             get { return (AllFlags & TcpFields.TCP_CWR_MASK) != 0; }
             set { setFlag(value, TcpFields.TCP_CWR_MASK); }
@@ -314,18 +314,18 @@ namespace PacketDotNet
         /// <value>
         /// NS flag
         /// </value>
-        virtual public bool NS
+        virtual public Boolean NS
         {
             get { return (AllFlags & TcpFields.TCP_NS_MASK) != 0; }
             set { setFlag(value, TcpFields.TCP_NS_MASK); }
         }
 
-        private void setFlag(bool on, int MASK)
+        private void setFlag(Boolean on, Int32 MASK)
         {
             if (on)
-                AllFlags = (ushort)(AllFlags | MASK);
+                AllFlags = (UInt16)(AllFlags | MASK);
             else
-                AllFlags = (ushort)(AllFlags & ~MASK);
+                AllFlags = (UInt16)(AllFlags & ~MASK);
         }
 
         /// <summary> Fetch ascii escape sequence of the color associated with this packet type.</summary>
@@ -340,15 +340,15 @@ namespace PacketDotNet
         /// <summary>
         /// Create a new TCP packet from values
         /// </summary>
-        public TcpPacket(ushort SourcePort,
-                         ushort DestinationPort)
+        public TcpPacket(UInt16 SourcePort,
+                         UInt16 DestinationPort)
         {
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int length = TcpFields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = TcpFields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             // make this packet valid
@@ -448,7 +448,7 @@ namespace PacketDotNet
         /// Computes the TCP checksum. Does not update the current checksum value
         /// </summary>
         /// <returns> The calculated TCP checksum.</returns>
-        public int CalculateTCPChecksum()
+        public Int32 CalculateTCPChecksum()
         {
             var newChecksum = CalculateChecksum(TransportChecksumOption.AttachPseudoIPHeader);
             return newChecksum;
@@ -460,11 +460,11 @@ namespace PacketDotNet
         public void UpdateTCPChecksum()
         {
             log.Debug("");
-            this.Checksum = (ushort)CalculateTCPChecksum();
+            this.Checksum = (UInt16)CalculateTCPChecksum();
         }
 
         /// <summary> Fetch the urgent pointer.</summary>
-        public int UrgentPointer
+        public Int32 UrgentPointer
         {
             get
             {
@@ -487,7 +487,7 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public byte[] Options
+        public Byte[] Options
         {
             get
             {
@@ -496,10 +496,10 @@ namespace PacketDotNet
                     throw new System.NotImplementedException("Urg == true not implemented yet");
                 }
 
-                int optionsOffset = TcpFields.UrgentPointerPosition + TcpFields.UrgentPointerLength;
-                int optionsLength = (DataOffset * 4) - optionsOffset;
+                Int32 optionsOffset = TcpFields.UrgentPointerPosition + TcpFields.UrgentPointerLength;
+                Int32 optionsLength = (DataOffset * 4) - optionsOffset;
 
-                byte[] optionBytes = new byte[optionsLength];
+                Byte[] optionBytes = new Byte[optionsLength];
                 Array.Copy(header.Bytes, header.Offset + optionsOffset,
                            optionBytes, 0,
                            optionsLength);
@@ -517,11 +517,11 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="List&lt;Option&gt;"/>
         /// </returns>
-        private List<Option> ParseOptions(byte[] optionBytes)
+        private List<Option> ParseOptions(Byte[] optionBytes)
         {
-            int offset = 0;
+            Int32 offset = 0;
             OptionTypes type;
-            byte length;
+            Byte length;
 
             if(optionBytes.Length == 0)
                 return null;
@@ -619,11 +619,11 @@ namespace PacketDotNet
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -634,7 +634,7 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Normal || outputFormat == StringOutputType.Colored)
             {
                 // build flagstring
-                string flags = "{";
+                String flags = "{";
                 if (Urg)
                     flags += "urg[0x" + System.Convert.ToString(UrgentPointer, 16) + "]|";
                 if (Ack)
@@ -660,7 +660,7 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("source port", SourcePort.ToString());
                 properties.Add("destination port", DestinationPort.ToString());
                 properties.Add("sequence number", SequenceNumber.ToString() + " (0x" + SequenceNumber.ToString("x") + ")");
@@ -668,7 +668,7 @@ namespace PacketDotNet
                 // TODO: Implement a HeaderLength property for TCPPacket
                 //properties.Add("header length", HeaderLength.ToString());
                 properties.Add("flags", "(0x" + AllFlags.ToString("x") + ")");
-                string flags = Convert.ToString(AllFlags, 2).PadLeft(8, '0');
+                String flags = Convert.ToString(AllFlags, 2).PadLeft(8, '0');
                 properties.Add("", flags[0] + "... .... = [" + flags[0] + "] congestion window reduced");
                 properties.Add(" ", "." + flags[1] + ".. .... = [" + flags[1] + "] ECN - echo");
                 properties.Add("  ", ".." + flags[2] + ". .... = [" + flags[2] + "] urgent");
@@ -683,14 +683,14 @@ namespace PacketDotNet
                 var parsedOptions = OptionsCollection;
                 if(parsedOptions != null)
                 {
-                    for(int i = 0; i < parsedOptions.Count; i++)
+                    for(Int32 i = 0; i < parsedOptions.Count; i++)
                     {
                         properties.Add("option" + (i + 1).ToString(), parsedOptions[i].ToString());
                     }
                 }
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("TCP:  ******* TCP - \"Transmission Control Protocol\" - offset=? length=" + TotalPacketLength);
@@ -726,8 +726,8 @@ namespace PacketDotNet
             var rnd = new Random();
 
             // create a randomized TcpPacket
-            var srcPort = (ushort)rnd.Next(ushort.MinValue, ushort.MaxValue);
-            var dstPort = (ushort)rnd.Next(ushort.MinValue, ushort.MaxValue);
+            var srcPort = (UInt16)rnd.Next(UInt16.MinValue, UInt16.MaxValue);
+            var dstPort = (UInt16)rnd.Next(UInt16.MinValue, UInt16.MaxValue);
             var tcpPacket = new TcpPacket(srcPort, dstPort);
 
             return tcpPacket;

--- a/PacketDotNet/TransportPacket.cs
+++ b/PacketDotNet/TransportPacket.cs
@@ -45,7 +45,7 @@ namespace PacketDotNet
         /// <value>
         /// The Checksum version
         /// </value>
-        public abstract ushort Checksum
+        public abstract UInt16 Checksum
         {
             get;
             set;
@@ -59,7 +59,7 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.Int32"/>
         /// </returns>
-        internal int CalculateChecksum(TransportChecksumOption option)
+        internal Int32 CalculateChecksum(TransportChecksumOption option)
         {
             // save the checksum field value so it can be restored, altering the checksum is not
             // an intended side effect of this method
@@ -70,13 +70,13 @@ namespace PacketDotNet
             Checksum = 0;
 
             // copy the tcp section with data
-            byte[] dataToChecksum = ((IpPacket)ParentPacket).PayloadPacket.Bytes;
+            Byte[] dataToChecksum = ((IpPacket)ParentPacket).PayloadPacket.Bytes;
 
              if (option == TransportChecksumOption.AttachPseudoIPHeader)
                 dataToChecksum = ((IpPacket)ParentPacket).AttachPseudoIPHeader(dataToChecksum);
 
             // calculate the one's complement sum of the tcp header
-            int cs = ChecksumUtils.OnesComplementSum(dataToChecksum);
+            Int32 cs = ChecksumUtils.OnesComplementSum(dataToChecksum);
 
             // restore the checksum field value
             Checksum = originalChecksum;
@@ -93,7 +93,7 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.Boolean"/>
         /// </returns>
-        public virtual bool IsValidChecksum(TransportChecksumOption option)
+        public virtual Boolean IsValidChecksum(TransportChecksumOption option)
         {
             var upperLayer = ((IpPacket)ParentPacket).PayloadPacket.Bytes;
 
@@ -104,7 +104,7 @@ namespace PacketDotNet
                 upperLayer = ((IpPacket)ParentPacket).AttachPseudoIPHeader(upperLayer);
 
             var onesSum = ChecksumUtils.OnesSum(upperLayer);
-            const int expectedOnesSum = 0xffff;
+            const Int32 expectedOnesSum = 0xffff;
             log.DebugFormat("onesSum {0} expected {1}",
                             onesSum,
                             expectedOnesSum);

--- a/PacketDotNet/UdpFields.cs
+++ b/PacketDotNet/UdpFields.cs
@@ -17,6 +17,9 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
+
+using System;
+
 namespace PacketDotNet
 {
     /// <summary>
@@ -26,21 +29,21 @@ namespace PacketDotNet
     public struct UdpFields
     {
         /// <summary> Length of a UDP port in bytes.</summary>
-        public readonly static int PortLength = 2;
+        public readonly static Int32 PortLength = 2;
         /// <summary> Length of the header length field in bytes.</summary>
-        public readonly static int HeaderLengthLength = 2;
+        public readonly static Int32 HeaderLengthLength = 2;
         /// <summary> Length of the checksum field in bytes.</summary>
-        public readonly static int ChecksumLength = 2;
+        public readonly static Int32 ChecksumLength = 2;
         /// <summary> Position of the source port.</summary>
-        public readonly static int SourcePortPosition = 0;
+        public readonly static Int32 SourcePortPosition = 0;
         /// <summary> Position of the destination port.</summary>
-        public readonly static int DestinationPortPosition;
+        public readonly static Int32 DestinationPortPosition;
         /// <summary> Position of the header length.</summary>
-        public readonly static int HeaderLengthPosition;
+        public readonly static Int32 HeaderLengthPosition;
         /// <summary> Position of the header checksum length.</summary>
-        public readonly static int ChecksumPosition;
+        public readonly static Int32 ChecksumPosition;
         /// <summary> Length of a UDP header in bytes.</summary>
-        public readonly static int HeaderLength; // == 8
+        public readonly static Int32 HeaderLength; // == 8
 
         static UdpFields()
         {

--- a/PacketDotNet/UdpPacket.cs
+++ b/PacketDotNet/UdpPacket.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
 PacketDotNet is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@ along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
  */
-﻿using System;
+ using System;
 using System.Collections.Generic;
 using System.Text;
 using PacketDotNet.Utils;
@@ -43,7 +43,7 @@ namespace PacketDotNet
 #endif
 
         /// <summary> Fetch the port number on the source host.</summary>
-        virtual public ushort SourcePort
+        virtual public UInt16 SourcePort
         {
             get
             {
@@ -58,7 +58,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Fetch the port number on the target host.</summary>
-        virtual public ushort DestinationPort
+        virtual public UInt16 DestinationPort
         {
             get
             {
@@ -79,7 +79,7 @@ namespace PacketDotNet
         /// Length in bytes of the header and payload, minimum size of 8,
         /// the size of the Udp header
         /// </value>
-        virtual public int Length
+        virtual public Int32 Length
         {
             get
             {
@@ -99,7 +99,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Fetch the header checksum.</summary>
-        override public ushort Checksum
+        override public UInt16 Checksum
         {
             get
             {
@@ -117,7 +117,7 @@ namespace PacketDotNet
         }
 
         /// <summary> Check if the UDP packet is valid, checksum-wise.</summary>
-        public bool ValidChecksum
+        public Boolean ValidChecksum
         {
             get
             {
@@ -133,7 +133,7 @@ namespace PacketDotNet
         /// <value>
         /// True if the udp checksum is valid
         /// </value>
-        virtual public bool ValidUDPChecksum
+        virtual public Boolean ValidUDPChecksum
         {
             get
             {
@@ -172,14 +172,14 @@ namespace PacketDotNet
         /// <param name="DestinationPort">
         /// A <see cref="System.UInt16"/>
         /// </param>
-        public UdpPacket(ushort SourcePort, ushort DestinationPort)
+        public UdpPacket(UInt16 SourcePort, UInt16 DestinationPort)
         {
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int length = UdpFields.HeaderLength;
-            var headerBytes = new byte[length];
+            Int32 offset = 0;
+            Int32 length = UdpFields.HeaderLength;
+            var headerBytes = new Byte[length];
             header = new ByteArraySegment(headerBytes, offset, length);
 
             // set instance values
@@ -204,8 +204,8 @@ namespace PacketDotNet
             payloadPacketOrData = new PacketOrByteArraySegment();
 
             // is this packet going to port 7 or 9? if so it might be a WakeOnLan packet
-            const int wakeOnLanPort0 = 7;
-            const int wakeOnLanPort1 = 9;
+            const Int32 wakeOnLanPort0 = 7;
+            const Int32 wakeOnLanPort1 = 9;
             if(DestinationPort.Equals(wakeOnLanPort0) || DestinationPort.Equals (wakeOnLanPort1))
             {
                 payloadPacketOrData.ThePacket = new WakeOnLanPacket(header.EncapsulatedBytes());
@@ -215,7 +215,7 @@ namespace PacketDotNet
                 payloadPacketOrData.TheByteArraySegment = header.EncapsulatedBytes();
             }
 
-            const int l2TPport = 1701;
+            const Int32 l2TPport = 1701;
             if (DestinationPort.Equals(l2TPport) && DestinationPort.Equals(l2TPport))
             {
                 var payload = header.EncapsulatedBytes();
@@ -243,7 +243,7 @@ namespace PacketDotNet
         /// Calculates the UDP checksum, optionally updating the UDP checksum header.
         /// </summary>
         /// <returns>The calculated UDP checksum.</returns>
-        public int CalculateUDPChecksum()
+        public Int32 CalculateUDPChecksum()
         {
             var newChecksum = CalculateChecksum(TransportChecksumOption.AttachPseudoIPHeader);
             return newChecksum;
@@ -254,15 +254,15 @@ namespace PacketDotNet
         /// </summary>
         public void UpdateUDPChecksum()
         {
-            this.Checksum = (ushort)CalculateUDPChecksum();
+            this.Checksum = (UInt16)CalculateUDPChecksum();
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -282,14 +282,14 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("source", SourcePort.ToString());
                 properties.Add("destination", DestinationPort.ToString());
                 properties.Add("length", Length.ToString());
                 properties.Add("checksum", "0x" + Checksum.ToString("x") + " [" + (ValidUDPChecksum ? "valid" : "invalid") + "]");
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("UDP:  ******* UDP - \"User Datagram Protocol\" - offset=? length=" + TotalPacketLength);
@@ -316,8 +316,8 @@ namespace PacketDotNet
         public static UdpPacket RandomPacket()
         {
             var rnd = new Random();
-            var SourcePort = (ushort)rnd.Next(ushort.MinValue, ushort.MaxValue);
-            var DestinationPort = (ushort)rnd.Next(ushort.MinValue, ushort.MaxValue);
+            var SourcePort = (UInt16)rnd.Next(UInt16.MinValue, UInt16.MaxValue);
+            var DestinationPort = (UInt16)rnd.Next(UInt16.MinValue, UInt16.MaxValue);
 
             return new UdpPacket(SourcePort, DestinationPort);
         }

--- a/PacketDotNet/Utils/AnsiEscapeSequences.cs
+++ b/PacketDotNet/Utils/AnsiEscapeSequences.cs
@@ -64,14 +64,14 @@ namespace PacketDotNet.Utils
         public readonly static String LightGrayBackground;
 #pragma warning restore 1591
 
-        private static string BuildValue(string ColorCode)
+        private static String BuildValue(String ColorCode)
         {
             return EscapeBegin + ColorCode + EscapeEnd;
         }
 
         static AnsiEscapeSequences()
         {
-            EscapeBegin = "" + (char) 27 + "[";
+            EscapeBegin = "" + (Char) 27 + "[";
             Reset = BuildValue("0");
             Bold = BuildValue("0;1");
             Underline = BuildValue("0;4");

--- a/PacketDotNet/Utils/ByteArraySegment.cs
+++ b/PacketDotNet/Utils/ByteArraySegment.cs
@@ -36,18 +36,18 @@ namespace PacketDotNet.Utils
 #pragma warning restore 0169, 0649
 #endif
 
-        private int length;
+        private Int32 length;
 
         /// <value>
         /// The byte[] array
         /// </value>
-        public byte[] Bytes { get; private set; }
+        public Byte[] Bytes { get; private set; }
 
         /// <value>
         /// The maximum number of bytes we should treat Bytes as having, allows
         /// for controling the number of bytes produced by EncapsulatedBytes()
         /// </value>
-        public int BytesLength { get; private set; }
+        public Int32 BytesLength { get; private set; }
 
         /// <value>
         /// Number of bytes beyond the offset into Bytes
@@ -55,7 +55,7 @@ namespace PacketDotNet.Utils
         /// Take care when setting this parameter as many things are based on
         /// the value of this property being correct
         /// </value>
-        public int Length
+        public Int32 Length
         {
             get { return length; }
             set
@@ -72,7 +72,7 @@ namespace PacketDotNet.Utils
         /// <value>
         /// Offset into Bytes
         /// </value>
-        public int Offset { get; private set; }
+        public Int32 Offset { get; private set; }
 
         /// <summary>
         /// Constructor
@@ -80,7 +80,7 @@ namespace PacketDotNet.Utils
         /// <param name="Bytes">
         /// A <see cref="T:System.Byte[]"/>
         /// </param>
-        public ByteArraySegment(byte[] Bytes) :
+        public ByteArraySegment(Byte[] Bytes) :
             this(Bytes, 0, Bytes.Length)
         { }
 
@@ -97,7 +97,7 @@ namespace PacketDotNet.Utils
         /// <param name="Length">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public ByteArraySegment(byte[] Bytes, int Offset, int Length)
+        public ByteArraySegment(Byte[] Bytes, Int32 Offset, Int32 Length)
             : this(Bytes, Offset, Length, Bytes.Length)
         { }
 
@@ -116,7 +116,7 @@ namespace PacketDotNet.Utils
         /// <param name="BytesLength">
         /// A <see cref="System.Int32"/>
         /// </param>
-        public ByteArraySegment(byte[] Bytes, int Offset, int Length, int BytesLength)
+        public ByteArraySegment(Byte[] Bytes, Int32 Offset, Int32 Length, Int32 BytesLength)
         {
             log.DebugFormat("Bytes.Length {0}, Offset {1}, Length {2}, BytesLength {3}",
                             Bytes.Length,
@@ -153,14 +153,14 @@ namespace PacketDotNet.Utils
         /// <returns>
         /// A <see cref="System.Byte"/>
         /// </returns>
-        public byte[] ActualBytes()
+        public Byte[] ActualBytes()
         {
             log.DebugFormat("{0}", ToString());
 
             if(NeedsCopyForActualBytes)
             {
                 log.Debug("needs copy");
-                var newBytes = new byte[Length];
+                var newBytes = new Byte[Length];
                 Array.Copy(Bytes, Offset, newBytes, 0, Length);
                 return newBytes;
             } else
@@ -177,7 +177,7 @@ namespace PacketDotNet.Utils
         /// <returns>
         /// A <see cref="System.Boolean"/>
         /// </returns>
-        public bool NeedsCopyForActualBytes
+        public Boolean NeedsCopyForActualBytes
         {
             get
             {
@@ -216,11 +216,11 @@ namespace PacketDotNet.Utils
         /// <returns>
         /// A <see cref="ByteArraySegment"/>
         /// </returns>
-        public ByteArraySegment EncapsulatedBytes(int NewSegmentLength)
+        public ByteArraySegment EncapsulatedBytes(Int32 NewSegmentLength)
         {
             log.DebugFormat("NewSegmentLength {0}", NewSegmentLength);
 
-            int startingOffset = Offset + Length; // start at the end of the current segment
+            Int32 startingOffset = Offset + Length; // start at the end of the current segment
             log.DebugFormat("startingOffset({0}) = Offset({1}) + Length({2})",
                             startingOffset,
                             Offset,
@@ -231,7 +231,7 @@ namespace PacketDotNet.Utils
             NewSegmentLength = Math.Min(NewSegmentLength, BytesLength - startingOffset);
 
             // calculate the ByteLength property of the new ByteArraySegment
-            int NewByteLength = startingOffset + NewSegmentLength;
+            Int32 NewByteLength = startingOffset + NewSegmentLength;
 
             log.DebugFormat("NewSegmentLength {0}, NewByteLength {1}, BytesLength {2}",
                             NewSegmentLength, NewByteLength, BytesLength);
@@ -245,9 +245,9 @@ namespace PacketDotNet.Utils
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public override string ToString ()
+        public override String ToString ()
         {
-            return string.Format("[ByteArraySegment: Length={0}, Bytes.Length={1}, BytesLength={2}, Offset={3}, NeedsCopyForActualBytes={4}]",
+            return String.Format("[ByteArraySegment: Length={0}, Bytes.Length={1}, BytesLength={2}, Offset={3}, NeedsCopyForActualBytes={4}]",
                                  Length, Bytes.Length, BytesLength, Offset, NeedsCopyForActualBytes);
         }
     }

--- a/PacketDotNet/Utils/ChecksumUtils.cs
+++ b/PacketDotNet/Utils/ChecksumUtils.cs
@@ -42,7 +42,7 @@ namespace PacketDotNet.Utils
         /// <summary>
         /// Computes the one's complement sum on a byte array
         /// </summary>
-        public static int OnesComplementSum(byte[] bytes)
+        public static Int32 OnesComplementSum(Byte[] bytes)
         {
             //just complement the one's sum
             return OnesComplementSum(bytes, 0, bytes.Length);
@@ -51,7 +51,7 @@ namespace PacketDotNet.Utils
         /// <summary>
         /// Computes the one's complement sum on a byte array
         /// </summary>
-        public static int OnesComplementSum(byte[] bytes, int start, int len)
+        public static Int32 OnesComplementSum(Byte[] bytes, Int32 start, Int32 len)
         {
             //just complement the one's sum
             return (~OnesSum(bytes, start, len)) & 0xFFFF;
@@ -66,7 +66,7 @@ namespace PacketDotNet.Utils
         /// <returns>
         /// A <see cref="System.Int32"/>
         /// </returns>
-        public static int OnesSum(byte[] bytes)
+        public static Int32 OnesSum(Byte[] bytes)
         {
             return OnesSum(bytes, 0, bytes.Length);
         }
@@ -87,7 +87,7 @@ namespace PacketDotNet.Utils
         /// <returns>
         /// A <see cref="System.Int32"/>
         /// </returns>
-        public static int OnesSum(byte[] bytes, int start, int len)
+        public static Int32 OnesSum(Byte[] bytes, Int32 start, Int32 len)
         {
             MemoryStream memStream = new MemoryStream(bytes, start, len);
             BinaryReader br = new BinaryReader(memStream);

--- a/PacketDotNet/Utils/Crc32.cs
+++ b/PacketDotNet/Utils/Crc32.cs
@@ -23,10 +23,10 @@ namespace PacketDotNet.Utils
 
         /// <summary>Gets the default polynomial (used in WinZip, Ethernet, etc.)</summary>
         /// <remarks>The default polynomial is a bit-reflected version of the standard polynomial 0x04C11DB7 used by WinZip, Ethernet, etc.</remarks>
-        public static readonly uint DefaultPolynomial = 0xEDB88320; // Bitwise reflection of 0x04C11DB7;
-        private const uint _allOnes = 0xffffffff;
-        private uint _crc;
-        private readonly uint[] _crc32Table;
+        public static readonly UInt32 DefaultPolynomial = 0xEDB88320; // Bitwise reflection of 0x04C11DB7;
+        private const UInt32 _allOnes = 0xffffffff;
+        private UInt32 _crc;
+        private readonly UInt32[] _crc32Table;
         private static readonly Hashtable _crc32TablesCache;
         private static readonly Crc32 _defaultCRC;
 
@@ -42,10 +42,10 @@ namespace PacketDotNet.Utils
 
         /// <summary>Creates a CRC32 object using the specified polynomial.</summary>
         /// <remarks>The polynomial should be supplied in its bit-reflected form. <see cref="DefaultPolynomial"/>.</remarks>
-        public Crc32(uint polynomial)
+        public Crc32(UInt32 polynomial)
         {
             HashSizeValue = 32;
-            _crc32Table = (uint[])_crc32TablesCache[polynomial];
+            _crc32Table = (UInt32[])_crc32TablesCache[polynomial];
             if (_crc32Table == null) {
                 _crc32Table = BuildCrc32Table(polynomial);
                 _crc32TablesCache.Add(polynomial, _crc32Table);
@@ -65,28 +65,28 @@ namespace PacketDotNet.Utils
         #region Public Methods
 
         /// <summary>Computes the CRC32 value for the given ASCII string using the <see cref="DefaultPolynomial"/>.</summary>
-        public static int Compute(string asciiString)
+        public static Int32 Compute(String asciiString)
         {
             _defaultCRC.Initialize();
             return ToInt32(_defaultCRC.ComputeHash(asciiString));
         }
 
         /// <summary>Computes the CRC32 value for the given input stream using the <see cref="DefaultPolynomial"/>.</summary>
-        public static int Compute(Stream inputStream)
+        public static Int32 Compute(Stream inputStream)
         {
             _defaultCRC.Initialize();
             return ToInt32(_defaultCRC.ComputeHash(inputStream));
         }
 
         /// <summary>Computes the CRC32 value for the input data using the <see cref="DefaultPolynomial"/>.</summary>
-        public static int Compute(byte[] buffer)
+        public static Int32 Compute(Byte[] buffer)
         {
             _defaultCRC.Initialize();
             return ToInt32(_defaultCRC.ComputeHash(buffer));
         }
 
         /// <summary>Computes the hash value for the input data using the <see cref="DefaultPolynomial"/>.</summary>
-        public static int Compute(byte[] buffer, int offset, int count)
+        public static Int32 Compute(Byte[] buffer, Int32 offset, Int32 count)
         {
             _defaultCRC.Initialize();
             return ToInt32(_defaultCRC.ComputeHash(buffer, offset, count));
@@ -94,18 +94,18 @@ namespace PacketDotNet.Utils
 
         /// <summary>Computes the hash value for the given ASCII string.</summary>
         /// <remarks>The computation preserves the internal state between the calls, so it can be used for computation of a stream data.</remarks>
-        public byte[] ComputeHash(string asciiString)
+        public Byte[] ComputeHash(String asciiString)
         {
-            byte[] rawBytes = Encoding.ASCII.GetBytes(asciiString);
+            Byte[] rawBytes = Encoding.ASCII.GetBytes(asciiString);
             return ComputeHash(rawBytes);
         }
 
         /// <summary>Computes the hash value for the given input stream.</summary>
         /// <remarks>The computation preserves the internal state between the calls, so it can be used for computation of a stream data.</remarks>
-        public new byte[] ComputeHash(Stream inputStream)
+        public new Byte[] ComputeHash(Stream inputStream)
         {
-            var buffer = new byte[4096];
-            int bytesRead;
+            var buffer = new Byte[4096];
+            Int32 bytesRead;
             while ((bytesRead = inputStream.Read(buffer, 0, 4096)) > 0) {
                 HashCore(buffer, 0, bytesRead);
             }
@@ -114,14 +114,14 @@ namespace PacketDotNet.Utils
 
         /// <summary>Computes the hash value for the input data.</summary>
         /// <remarks>The computation preserves the internal state between the calls, so it can be used for computation of a stream data.</remarks>
-        public new byte[] ComputeHash(byte[] buffer)
+        public new Byte[] ComputeHash(Byte[] buffer)
         {
             return ComputeHash(buffer, 0, buffer.Length);
         }
 
         /// <summary>Computes the hash value for the input data.</summary>
         /// <remarks>The computation preserves the internal state between the calls, so it can be used for computation of a stream data.</remarks>
-        public new byte[] ComputeHash(byte[] buffer, int offset, int count)
+        public new Byte[] ComputeHash(Byte[] buffer, Int32 offset, Int32 count)
         {
             HashCore(buffer, offset, count);
             return HashFinal();
@@ -138,25 +138,25 @@ namespace PacketDotNet.Utils
         #region Protected Methods
 
         /// <summary>Routes data written to the object into the hash algorithm for computing the hash.</summary>
-        protected override void HashCore(byte[] buffer, int offset, int count)
+        protected override void HashCore(Byte[] buffer, Int32 offset, Int32 count)
         {
-            for (int i = offset; i < count; i++) {
-                ulong ptr = (_crc & 0xFF) ^ buffer[i];
+            for (Int32 i = offset; i < count; i++) {
+                UInt64 ptr = (_crc & 0xFF) ^ buffer[i];
                 _crc >>= 8;
                 _crc ^= _crc32Table[ptr];
             }
         }
 
         /// <summary>Finalizes the hash computation after the last data is processed by the cryptographic stream object.</summary>
-        protected override byte[] HashFinal()
+        protected override Byte[] HashFinal()
         {
-            var finalHash = new byte[4];
-            ulong finalCrc = _crc ^ _allOnes;
+            var finalHash = new Byte[4];
+            UInt64 finalCrc = _crc ^ _allOnes;
 
-            finalHash[3] = (byte)((finalCrc >> 0) & 0xFF);
-            finalHash[2] = (byte)((finalCrc >> 8) & 0xFF);
-            finalHash[1] = (byte)((finalCrc >> 16) & 0xFF);
-            finalHash[0] = (byte)((finalCrc >> 24) & 0xFF);
+            finalHash[3] = (Byte)((finalCrc >> 0) & 0xFF);
+            finalHash[2] = (Byte)((finalCrc >> 8) & 0xFF);
+            finalHash[1] = (Byte)((finalCrc >> 16) & 0xFF);
+            finalHash[0] = (Byte)((finalCrc >> 24) & 0xFF);
 
             return finalHash;
         }
@@ -166,14 +166,14 @@ namespace PacketDotNet.Utils
         #region Private Methods
 
         // Builds a crc32 table given a polynomial
-        private static uint[] BuildCrc32Table(uint polynomial)
+        private static UInt32[] BuildCrc32Table(UInt32 polynomial)
         {
-            var table = new uint[256];
+            var table = new UInt32[256];
 
             // 256 values representing ASCII character codes.
-            for (int i = 0; i < 256; i++) {
-                var crc = (uint)i;
-                for (int j = 8; j > 0; j--) {
+            for (Int32 i = 0; i < 256; i++) {
+                var crc = (UInt32)i;
+                for (Int32 j = 8; j > 0; j--) {
                     if ((crc & 1) == 1)
                         crc = (crc >> 1) ^ polynomial;
                     else
@@ -185,7 +185,7 @@ namespace PacketDotNet.Utils
             return table;
         }
 
-        private static int ToInt32(byte[] buffer)
+        private static Int32 ToInt32(Byte[] buffer)
         {
             return BitConverter.ToInt32(buffer, 0);
         }

--- a/PacketDotNet/Utils/HexPrinter.cs
+++ b/PacketDotNet/Utils/HexPrinter.cs
@@ -42,13 +42,13 @@ namespace PacketDotNet.Utils
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public static string GetString(byte[] Byte,
-                                       int Offset,
-                                       int Length)
+        public static String GetString(Byte[] Byte,
+                                       Int32 Offset,
+                                       Int32 Length)
         {
             StringBuilder sb = new StringBuilder();
 
-            for(int i = Offset; i < Offset + Length; i++)
+            for(Int32 i = Offset; i < Offset + Length; i++)
             {
                 sb.AppendFormat("[{0:x2}]", Byte[i]);
             }
@@ -65,12 +65,12 @@ namespace PacketDotNet.Utils
         /// <returns>
         /// A <see cref="System.String"/>
         /// </returns>
-        public static string PrintMACAddress(PhysicalAddress address)
+        public static String PrintMACAddress(PhysicalAddress address)
         {
-            byte[] bytes = address.GetAddressBytes();
-            string output = "";
+            Byte[] bytes = address.GetAddressBytes();
+            String output = "";
 
-            for(int i = 0; i < bytes.Length; i++)
+            for(Int32 i = 0; i < bytes.Length; i++)
             {
                 output += bytes[i].ToString("x").PadLeft(2, '0') + ":";
             }

--- a/PacketDotNet/Utils/RandomUtils.cs
+++ b/PacketDotNet/Utils/RandomUtils.cs
@@ -38,15 +38,15 @@ namespace PacketDotNet.Utils
         public static System.Net.IPAddress GetIPAddress(IpVersion version)
         {
             var rnd = new Random();
-            byte[] randomAddressBytes;
+            Byte[] randomAddressBytes;
 
             if(version == IpVersion.IPv4)
             {
-                randomAddressBytes = new byte[IPv4Fields.AddressLength];
+                randomAddressBytes = new Byte[IPv4Fields.AddressLength];
                 rnd.NextBytes(randomAddressBytes);
             } else if(version == IpVersion.IPv6)
             {
-                randomAddressBytes = new byte[IPv6Fields.AddressLength];
+                randomAddressBytes = new Byte[IPv6Fields.AddressLength];
                 rnd.NextBytes(randomAddressBytes);
             } else
             {
@@ -65,11 +65,11 @@ namespace PacketDotNet.Utils
         /// <returns>
         /// A <see cref="System.Int32"/>
         /// </returns>
-        public static int LongestStringLength(List<string> stringsList)
+        public static Int32 LongestStringLength(List<String> stringsList)
         {
-            string longest="";
+            String longest="";
 
-            foreach(string L in stringsList)
+            foreach(String L in stringsList)
             {
                 if (L.Length > longest.Length)
                 {

--- a/PacketDotNet/WakeOnLanPacket.cs
+++ b/PacketDotNet/WakeOnLanPacket.cs
@@ -63,15 +63,15 @@ namespace PacketDotNet
             log.Debug("");
 
             // allocate memory for this packet
-            int offset = 0;
-            int packetLength = syncSequence.Length + (EthernetFields.MacAddressLength * macRepetitions);
-            var packetBytes = new byte[packetLength];
+            Int32 offset = 0;
+            Int32 packetLength = syncSequence.Length + (EthernetFields.MacAddressLength * macRepetitions);
+            var packetBytes = new Byte[packetLength];
             var destinationMACBytes = destinationMAC.GetAddressBytes();
 
             // write the data to the payload
             // - synchronization sequence (6 bytes)
             // - destination MAC (16 copies of 6 bytes)
-            for(int i = 0; i < packetLength; i+=EthernetFields.MacAddressLength)
+            for(Int32 i = 0; i < packetLength; i+=EthernetFields.MacAddressLength)
             {
                 // copy the syncSequence on the first pass
                 if(i == 0)
@@ -116,7 +116,7 @@ namespace PacketDotNet
         {
             get
             {
-                byte[] destinationMAC = new byte[EthernetFields.MacAddressLength];
+                Byte[] destinationMAC = new Byte[EthernetFields.MacAddressLength];
                 Array.Copy(header.Bytes, header.Offset + syncSequence.Length,
                            destinationMAC, 0,
                            EthernetFields.MacAddressLength);
@@ -124,7 +124,7 @@ namespace PacketDotNet
             }
             set
             {
-                byte[] destinationMAC = value.GetAddressBytes();
+                Byte[] destinationMAC = value.GetAddressBytes();
                 Array.Copy(destinationMAC, 0,
                            header.Bytes, header.Offset + syncSequence.Length,
                            EthernetFields.MacAddressLength);
@@ -145,7 +145,7 @@ namespace PacketDotNet
         {
             var rnd = new Random();
 
-            byte[] destAddress = new byte[EthernetFields.MacAddressLength];
+            Byte[] destAddress = new Byte[EthernetFields.MacAddressLength];
 
             rnd.NextBytes(destAddress);
 
@@ -160,7 +160,7 @@ namespace PacketDotNet
         /// <returns>
         /// True if the Wake-On-LAN payload is valid
         /// </returns>
-        public bool IsValid()
+        public Boolean IsValid()
         {
             return IsValid(header);
         }
@@ -174,19 +174,19 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.Boolean"/>
         /// </returns>
-        public static bool IsValid(ByteArraySegment bas)
+        public static Boolean IsValid(ByteArraySegment bas)
         {
             // fetch the destination MAC from the payload
-            byte[] destinationMAC = new byte[EthernetFields.MacAddressLength];
+            Byte[] destinationMAC = new Byte[EthernetFields.MacAddressLength];
             Array.Copy(bas.Bytes, bas.Offset + syncSequence.Length, destinationMAC, 0, EthernetFields.MacAddressLength);
 
             // the buffer is used to store both the synchronization sequence
             //  and the MAC address, both of which are the same length (in bytes)
-            byte[] buffer = new byte[EthernetFields.MacAddressLength];
+            Byte[] buffer = new Byte[EthernetFields.MacAddressLength];
 
             // validate the 16 repetitions of the wolDestinationMAC
             // - verify that the wolDestinationMAC address repeats 16 times in sequence
-            for(int i = 0; i<(EthernetFields.MacAddressLength * macRepetitions); i+=EthernetFields.MacAddressLength)
+            for(Int32 i = 0; i<(EthernetFields.MacAddressLength * macRepetitions); i+=EthernetFields.MacAddressLength)
             {
                 // Extract the sample from the payload for comparison
                 Array.Copy(bas.Bytes, bas.Offset + i, buffer, 0, buffer.Length);
@@ -217,7 +217,7 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.Boolean"/>
         /// </returns>
-        public override bool Equals(object obj)
+        public override Boolean Equals(Object obj)
         {
             // Check for null values and compare run-time types.
             if (obj == null || GetType() != obj.GetType())
@@ -234,17 +234,17 @@ namespace PacketDotNet
         /// <returns>
         /// A <see cref="System.Int32"/>
         /// </returns>
-        public override int GetHashCode()
+        public override Int32 GetHashCode()
         {
             return header.GetHashCode();
         }
 
         /// <summary cref="Packet.ToString(StringOutputType)" />
-        public override string ToString(StringOutputType outputFormat)
+        public override String ToString(StringOutputType outputFormat)
         {
             var buffer = new StringBuilder();
-            string color = "";
-            string colorEscape = "";
+            String color = "";
+            String colorEscape = "";
 
             if(outputFormat == StringOutputType.Colored || outputFormat == StringOutputType.VerboseColored)
             {
@@ -263,11 +263,11 @@ namespace PacketDotNet
             if(outputFormat == StringOutputType.Verbose || outputFormat == StringOutputType.VerboseColored)
             {
                 // collect the properties and their value
-                Dictionary<string,string> properties = new Dictionary<string,string>();
+                Dictionary<String,String> properties = new Dictionary<String,String>();
                 properties.Add("destination", HexPrinter.PrintMACAddress(DestinationMAC));
 
                 // calculate the padding needed to right-justify the property names
-                int padLength = Utils.RandomUtils.LongestStringLength(new List<string>(properties.Keys));
+                Int32 padLength = Utils.RandomUtils.LongestStringLength(new List<String>(properties.Keys));
 
                 // build the output string
                 buffer.AppendLine("WOL:  ******* WOL - \"Wake-On-Lan\" - offset=? length=" + TotalPacketLength);
@@ -290,10 +290,10 @@ namespace PacketDotNet
         #region Members
 
         // the WOL synchronization sequence
-        private static readonly byte[] syncSequence = new byte[6] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+        private static readonly Byte[] syncSequence = new Byte[6] { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 
         // the number of times the Destination MAC appears in the payload
-        private static readonly int macRepetitions = 16;
+        private static readonly Int32 macRepetitions = 16;
 
         #endregion
     }

--- a/Test/ByteSetupMethods.cs
+++ b/Test/ByteSetupMethods.cs
@@ -4,14 +4,14 @@ namespace Test
 {
     public class ByteSetupMethods
     {
-        public static void Setup(out byte[] bytes, out int testRuns, out int startIndex,
-                            out int expectedValue)
+        public static void Setup(out Byte[] bytes, out Int32 testRuns, out Int32 startIndex,
+                            out Int32 expectedValue)
         {
             testRuns = 40000000; // needs to be enough runs, taking at least seconds, to get
                                  // an accurate result
 
             // presume that bytes contains a network ordered 32bit value
-            bytes = new byte[5];
+            bytes = new Byte[5];
             bytes[0] = 0xFF;
             bytes[1] = 0x0A;
             bytes[2] = 0x0B;

--- a/Test/Misc/ChecksumUtilsTest.cs
+++ b/Test/Misc/ChecksumUtilsTest.cs
@@ -30,7 +30,7 @@ namespace Test.Misc
         public void OnesSum()
         {
             var bytes = new Byte[4096];
-            for(int i = 0; i < bytes.Length; i++)
+            for(Int32 i = 0; i < bytes.Length; i++)
             {
                 bytes[i] = 0x7f;
             }

--- a/Test/Misc/PacketTest.cs
+++ b/Test/Misc/PacketTest.cs
@@ -30,10 +30,10 @@ namespace Test.Misc
         [Test]
         public void TestSettingPayloadData()
         {
-            byte[] data = new byte[10];
-            for(int i = 0; i < data.Length; i++)
+            Byte[] data = new Byte[10];
+            for(Int32 i = 0; i < data.Length; i++)
             {
-                data[i] = (byte)i;
+                data[i] = (Byte)i;
             }
 
             // NOTE: we use TcpPacket because it has a simple constructor. We can't

--- a/Test/Misc/StringOutput.cs
+++ b/Test/Misc/StringOutput.cs
@@ -35,13 +35,13 @@ namespace Test.Misc
 
         private class FileAndPacketIndexes
         {
-            public string Filename;
-            public List<int> PacketIndexes;
-            public List<string> PacketDescription;
+            public String Filename;
+            public List<Int32> PacketIndexes;
+            public List<String> PacketDescription;
 
-            public FileAndPacketIndexes(string Filename,
-                                        List<int> PacketIndexes,
-                                        List<string> PacketDescription)
+            public FileAndPacketIndexes(String Filename,
+                                        List<Int32> PacketIndexes,
+                                        List<String> PacketDescription)
             {
                 this.Filename = Filename;
                 this.PacketIndexes = PacketIndexes;
@@ -68,46 +68,46 @@ namespace Test.Misc
 
             // ethernet arp request and response
             fileAndPacketIndexes.Add(new FileAndPacketIndexes(prefix + "arp_request_response.pcap",
-                                                              new List<int>(new int[] {0, 1}),
-                                                              new List<string>(new string[] { "ethernet arp request",
+                                                              new List<Int32>(new Int32[] {0, 1}),
+                                                              new List<String>(new String[] { "ethernet arp request",
                                                                                               "ethernet arp response"})));
 
             // linux cooked capture, ipv4, tcp
             fileAndPacketIndexes.Add(new FileAndPacketIndexes(prefix + "LinuxCookedCapture.pcap",
-                                                              new List<int>(new int[] {2}),
-                                                              new List<string>(new string[] { "linux cooked capture, ipv4, tcp"})));
+                                                              new List<Int32>(new Int32[] {2}),
+                                                              new List<String>(new String[] { "linux cooked capture, ipv4, tcp"})));
 
             // ethernet, ipv6, icmpv6
             fileAndPacketIndexes.Add(new FileAndPacketIndexes(prefix + "ipv6_icmpv6_packet.pcap",
-                                                              new List<int>(new int[] {0}),
-                                                              new List<string>(new string[] { "ethernet, ipv6, icmpv6"})));
+                                                              new List<Int32>(new Int32[] {0}),
+                                                              new List<String>(new String[] { "ethernet, ipv6, icmpv6"})));
 
             // ethernet, PPPoE, PPP, ipv4, udp
             fileAndPacketIndexes.Add(new FileAndPacketIndexes(prefix + "PPPoEPPP.pcap",
-                                                              new List<int>(new int[] {1}),
-                                                              new List<string>(new string[] { "ethernet, PPPoE, PPP, ipv4, udp"})));
+                                                              new List<Int32>(new Int32[] {1}),
+                                                              new List<String>(new String[] { "ethernet, PPPoE, PPP, ipv4, udp"})));
 
             expectedTotalPackets = 5;
         }
 
-        private static int fileAndPacketIndex;
+        private static Int32 fileAndPacketIndex;
 
         /// <summary>
         /// Index into FileAndPacketIndexes.PacketIndex
         /// </summary>
-        private static int currentPacketIndex;
+        private static Int32 currentPacketIndex;
 
-        private static string currentPacketDescription;
+        private static String currentPacketDescription;
 
-        private static string packetFileName;
-        private static int indexIntoPacketFile;
+        private static String packetFileName;
+        private static Int32 indexIntoPacketFile;
 
         private static FileAndPacketIndexes currentFAPI;
 
         private static SharpPcap.LibPcap.CaptureFileReaderDevice captureFileReader;
 
-        private static int totalPacketsReturned;
-        private static int expectedTotalPackets;
+        private static Int32 totalPacketsReturned;
+        private static Int32 expectedTotalPackets;
 
         private static Packet GetNextPacket()
         {

--- a/Test/PacketType/ArpPacketTest.cs
+++ b/Test/PacketType/ArpPacketTest.cs
@@ -45,8 +45,8 @@ namespace Test.PacketType
             Assert.AreEqual(senderIp, arpPacket.SenderProtocolAddress);
             Assert.AreEqual(targetIp, arpPacket.TargetProtocolAddress);
 
-            string senderMacAddress = "000461990154";
-            string targetMacAddress = "000000000000";
+            String senderMacAddress = "000461990154";
+            String targetMacAddress = "000000000000";
             Assert.AreEqual(senderMacAddress, arpPacket.SenderHardwareAddress.ToString());
             Assert.AreEqual(targetMacAddress, arpPacket.TargetHardwareAddress.ToString());
         }
@@ -63,8 +63,8 @@ namespace Test.PacketType
             Assert.AreEqual(senderIp, arpPacket.SenderProtocolAddress);
             Assert.AreEqual(targetIp, arpPacket.TargetProtocolAddress);
 
-            string senderMacAddress = "00216A020854";
-            string targetMacAddress = "000461990154";
+            String senderMacAddress = "00216A020854";
+            String targetMacAddress = "000461990154";
             Assert.AreEqual(senderMacAddress, arpPacket.SenderHardwareAddress.ToString());
             Assert.AreEqual(targetMacAddress, arpPacket.TargetHardwareAddress.ToString());
         }
@@ -76,7 +76,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             while((rawCapture = dev.GetNextPacket()) != null)
             {
                 var p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);
@@ -108,10 +108,10 @@ namespace Test.PacketType
         [Test]
         public void ConstructingFromValues()
         {
-            var localIPBytes = new byte[4] {124, 10, 10, 20};
+            var localIPBytes = new Byte[4] {124, 10, 10, 20};
             var localIP = new System.Net.IPAddress(localIPBytes);
 
-            var destinationIPBytes = new byte[4] {192, 168, 1, 10};
+            var destinationIPBytes = new Byte[4] {192, 168, 1, 10};
             var destinationIP = new System.Net.IPAddress(destinationIPBytes);
 
             var localMac = System.Net.NetworkInformation.PhysicalAddress.Parse("AA-BB-CC-DD-EE-FF");
@@ -166,7 +166,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundARP = false;
+            Boolean foundARP = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 var p = PacketDotNet.Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/DrdaPacketTest.cs
+++ b/Test/PacketType/DrdaPacketTest.cs
@@ -40,7 +40,7 @@ namespace Test.PacketType
         List<DrdaDDMPacket> sqlsttPackets = new List<DrdaDDMPacket>();
         DrdaDDMPacket prpsqlsttPacket;
         DrdaDDMPacket sqlattrPacket;
-        bool packetsLoaded = false;
+        Boolean packetsLoaded = false;
 
         [SetUp]
         public void Init()
@@ -48,7 +48,7 @@ namespace Test.PacketType
             if (packetsLoaded)
                 return;
             RawCapture raw;
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             var dev = new CaptureFileReaderDevice("../../CaptureFiles/db2_select.pcap");
             dev.Open();
 
@@ -172,7 +172,7 @@ namespace Test.PacketType
         [Test]
         public void TestSqlsttPacket()
         {
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             foreach (var packet in sqlsttPackets)
             {
                 Assert.IsNotNull(packet);
@@ -204,7 +204,7 @@ namespace Test.PacketType
         [Test]
         public void TestStringConverter()
         {
-            var bytes = new byte[] { 0xd8, 0xc4, 0xc2, 0xf2, 0x61, 0xd1, 0xe5, 0xd4 };
+            var bytes = new Byte[] { 0xd8, 0xc4, 0xc2, 0xf2, 0x61, 0xd1, 0xe5, 0xd4 };
             Assert.AreEqual("QDB2/JVM", MiscUtil.Conversion.StringConverter.EbcdicToAscii(bytes, 0, bytes.Length));
         }
     }

--- a/Test/PacketType/EthernetPacketTest.cs
+++ b/Test/PacketType/EthernetPacketTest.cs
@@ -170,7 +170,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             while((rawCapture = dev.GetNextPacket()) != null)
             {
                 Packet p = Packet.ParsePacket(rawCapture.LinkLayerType,
@@ -210,15 +210,15 @@ namespace Test.PacketType
         public void EthernetConstructorFromMacAddresses()
         {
             var srcHwAddressBytes = new Byte[EthernetFields.MacAddressLength];
-            for(int i = 0; i < srcHwAddressBytes.Length; i++)
+            for(Int32 i = 0; i < srcHwAddressBytes.Length; i++)
             {
-                srcHwAddressBytes[i] = (byte)i;
+                srcHwAddressBytes[i] = (Byte)i;
             }
 
             var dstHwAddressBytes = new Byte[EthernetFields.MacAddressLength];
-            for(int i = 0; i < dstHwAddressBytes.Length; i++)
+            for(Int32 i = 0; i < dstHwAddressBytes.Length; i++)
             {
-                dstHwAddressBytes[i] = (byte)(dstHwAddressBytes.Length - i);
+                dstHwAddressBytes[i] = (Byte)(dstHwAddressBytes.Length - i);
             }
 
             var srcHwAddress = new PhysicalAddress(srcHwAddressBytes);
@@ -227,7 +227,7 @@ namespace Test.PacketType
                                                     dstHwAddress,
                                                     EthernetPacketType.None);
 
-            int expectedLength = 14;
+            Int32 expectedLength = 14;
             Assert.AreEqual(expectedLength, ethernetPacket.Bytes.Length);
             //TODO: improve this here
             Console.WriteLine("ethernetPacket.ToString() {0}",
@@ -303,7 +303,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundEthernet = false;
+            Boolean foundEthernet = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 var ethernetPacket = new EthernetPacket(new ByteArraySegment(rawCapture.Data));

--- a/Test/PacketType/ICMPv4PacketTest.cs
+++ b/Test/PacketType/ICMPv4PacketTest.cs
@@ -36,7 +36,7 @@ namespace Test.PacketType
         /// </summary>
         [TestCase("../../CaptureFiles/ICMPv4.pcap", LinkLayers.Ethernet)]
         [TestCase("../../CaptureFiles/ICMPv4_raw_linklayer.pcap", LinkLayers.Raw)]
-        public void ICMPv4Parsing(string pcapPath, LinkLayers linkLayer)
+        public void ICMPv4Parsing(String pcapPath, LinkLayers linkLayer)
         {
             var dev = new CaptureFileReaderDevice(pcapPath);
             dev.Open();
@@ -58,8 +58,8 @@ namespace Test.PacketType
             Assert.AreEqual(0x6b00, icmp.Sequence);
 
             // check that the message matches
-            string expectedString = "abcdefghijklmnopqrstuvwabcdefghi";
-            byte[] expectedData = System.Text.ASCIIEncoding.ASCII.GetBytes(expectedString);
+            String expectedString = "abcdefghijklmnopqrstuvwabcdefghi";
+            Byte[] expectedData = System.Text.ASCIIEncoding.ASCII.GetBytes(expectedString);
             Assert.AreEqual(expectedData, icmp.Data);
         }
 
@@ -105,7 +105,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundicmp = false;
+            Boolean foundicmp = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 Packet p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/ICMPv6PacketTest.cs
+++ b/Test/PacketType/ICMPv6PacketTest.cs
@@ -126,7 +126,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundicmpv6 = false;
+            Boolean foundicmpv6 = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
 

--- a/Test/PacketType/IGMPv2PacketTest.cs
+++ b/Test/PacketType/IGMPv2PacketTest.cs
@@ -41,7 +41,7 @@ namespace Test.PacketType
 
             RawCapture rawCapture;
 
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             while((rawCapture = dev.GetNextPacket()) != null)
             {
                 var p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);
@@ -54,7 +54,7 @@ namespace Test.PacketType
                 {
                     Assert.AreEqual(igmp.Type, IGMPMessageType.MembershipQuery);
                     Assert.AreEqual(igmp.MaxResponseTime, 100);
-                    Assert.AreEqual(igmp.Checksum, BitConverter.ToInt16(new byte[2] { 0xEE, 0x9B }, 0));
+                    Assert.AreEqual(igmp.Checksum, BitConverter.ToInt16(new Byte[2] { 0xEE, 0x9B }, 0));
                     Assert.AreEqual(igmp.GroupAddress, IPAddress.Parse("0.0.0.0"));
                 }
 
@@ -62,7 +62,7 @@ namespace Test.PacketType
                 {
                     Assert.AreEqual(igmp.Type, IGMPMessageType.MembershipReportIGMPv2);
                     Assert.AreEqual(igmp.MaxResponseTime, 0.0);
-                    Assert.AreEqual(igmp.Checksum, BitConverter.ToInt16(new byte[2] { 0x08, 0xC3 }, 0));
+                    Assert.AreEqual(igmp.Checksum, BitConverter.ToInt16(new Byte[2] { 0x08, 0xC3 }, 0));
                     Assert.AreEqual(igmp.GroupAddress, IPAddress.Parse("224.0.1.60"));
                 }
 
@@ -114,7 +114,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundigmp = false;
+            Boolean foundigmp = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 Packet p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/IPv4PacketTest.cs
+++ b/Test/PacketType/IPv4PacketTest.cs
@@ -101,7 +101,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundipv4 = false;
+            Boolean foundipv4 = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 Packet p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/IPv6PacketTest.cs
+++ b/Test/PacketType/IPv6PacketTest.cs
@@ -57,7 +57,7 @@ namespace Test.PacketType
             Assert.AreEqual(16,  ip.PayloadPacket.Bytes.Length, "ip.PayloadPacket.Bytes.Length mismatch");
             Assert.AreEqual(255, ip.HopLimit);
             Assert.AreEqual(255, ip.TimeToLive);
-            Assert.AreEqual(0x3a, (byte)ip.NextHeader);
+            Assert.AreEqual(0x3a, (Byte)ip.NextHeader);
             Console.WriteLine("Failed: ip.ComputeIPChecksum() not implemented.");
             Assert.AreEqual(1221145299, rawCapture.Timeval.Seconds);
             Assert.AreEqual(453568.000, rawCapture.Timeval.MicroSeconds);
@@ -67,13 +67,13 @@ namespace Test.PacketType
         // for multiple LinkLayerType types
         [TestCase("../../CaptureFiles/ipv6_icmpv6_packet.pcap", LinkLayers.Ethernet)]
         [TestCase("../../CaptureFiles/ipv6_icmpv6_packet_raw_linklayer.pcap", LinkLayers.Raw)]
-        public void IPv6PacketTestParsing(string pcapPath, LinkLayers linkLayer)
+        public void IPv6PacketTestParsing(String pcapPath, LinkLayers linkLayer)
         {
             var dev = new CaptureFileReaderDevice(pcapPath);
             dev.Open();
 
             RawCapture rawCapture;
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             while((rawCapture = dev.GetNextPacket()) != null)
             {
                 var p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);
@@ -105,7 +105,7 @@ namespace Test.PacketType
             dev.Open();
 
             // checksums from wireshark of the capture file
-            int[] expectedChecksum = {0x41a2,
+            Int32[] expectedChecksum = {0x41a2,
                                       0x4201,
                                       0x5728,
                                       0xf448,
@@ -116,7 +116,7 @@ namespace Test.PacketType
                                       0x3725,
                                       0x3723};
 
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             RawCapture rawCapture;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
@@ -141,7 +141,7 @@ namespace Test.PacketType
         public void TCPDataIPv6()
         {
             String s = "-++++=== HELLLLOOO ===++++-";
-            byte[] data = System.Text.Encoding.UTF8.GetBytes(s);
+            Byte[] data = System.Text.Encoding.UTF8.GetBytes(s);
 
             //create random packet
             TcpPacket p = TcpPacket.RandomPacket();
@@ -211,7 +211,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundipv6 = false;
+            Boolean foundipv6 = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 Packet p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/Ieee80211/AckFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AckFrameTest.cs
@@ -100,7 +100,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				AckFrame frame = new AckFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/ActionFrameTest.cs
+++ b/Test/PacketType/Ieee80211/ActionFrameTest.cs
@@ -88,7 +88,7 @@ namespace Test.PacketType
                 
                 frame.Duration.Field = 0x1234;
                 
-                frame.PayloadData = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+                frame.PayloadData = new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
                 
                 frame.UpdateFrameCheckSequence ();
                 UInt32 fcs = frame.FrameCheckSequence;
@@ -113,7 +113,7 @@ namespace Test.PacketType
                 Assert.AreEqual ("222222222222", recreatedFrame.DestinationAddress.ToString ().ToUpper ());
                 Assert.AreEqual ("333333333333", recreatedFrame.BssId.ToString ().ToUpper ());
                 
-                CollectionAssert.AreEqual (new byte[]{0x01, 0x02, 0x03, 0x04, 0x05}, recreatedFrame.PayloadData);
+                CollectionAssert.AreEqual (new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05}, recreatedFrame.PayloadData);
                 
                 Assert.AreEqual (fcs, recreatedFrame.FrameCheckSequence);
             }
@@ -122,7 +122,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				ActionFrame frame = new ActionFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/AssociationRequestFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AssociationRequestFrameTest.cs
@@ -141,7 +141,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				AssociationRequestFrame frame = new AssociationRequestFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/AssociationResponseFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AssociationResponseFrameTest.cs
@@ -148,7 +148,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				AssociationResponseFrame frame = new AssociationResponseFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/AuthenticationFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AuthenticationFrameTest.cs
@@ -177,7 +177,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				AuthenticationFrame frame = new AuthenticationFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/BeaconFrameTest.cs
+++ b/Test/PacketType/Ieee80211/BeaconFrameTest.cs
@@ -129,7 +129,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				BeaconFrame frame = new BeaconFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/BlockAcknowledgmentFrameTest.cs
+++ b/Test/PacketType/Ieee80211/BlockAcknowledgmentFrameTest.cs
@@ -130,7 +130,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				BlockAcknowledgmentFrame frame = new BlockAcknowledgmentFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/BlockAcknowledgmentRequestFrameTest.cs
+++ b/Test/PacketType/Ieee80211/BlockAcknowledgmentRequestFrameTest.cs
@@ -125,7 +125,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				BlockAcknowledgmentRequestFrame frame = new BlockAcknowledgmentRequestFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/ContentionFreeEndFrameTest.cs
+++ b/Test/PacketType/Ieee80211/ContentionFreeEndFrameTest.cs
@@ -107,7 +107,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				ContentionFreeEndFrame frame = new ContentionFreeEndFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/CtsFrameTest.cs
+++ b/Test/PacketType/Ieee80211/CtsFrameTest.cs
@@ -100,7 +100,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				CtsFrame frame = new CtsFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/DataDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/DataDataFrameTest.cs
@@ -127,7 +127,7 @@ namespace Test.PacketType
                 frame.SourceAddress = PhysicalAddress.Parse ("222222222222");
                 frame.BssId = PhysicalAddress.Parse ("333333333333");
                 
-                frame.PayloadData = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+                frame.PayloadData = new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
                 
                 frame.UpdateFrameCheckSequence ();
                 UInt32 fcs = frame.FrameCheckSequence;
@@ -152,7 +152,7 @@ namespace Test.PacketType
                 Assert.AreEqual ("222222222222", recreatedFrame.SourceAddress.ToString ().ToUpper ());
                 Assert.AreEqual ("333333333333", recreatedFrame.BssId.ToString ().ToUpper ());
                 
-                CollectionAssert.AreEqual (new byte[]{0x01, 0x02, 0x03, 0x04, 0x05}, recreatedFrame.PayloadData);
+                CollectionAssert.AreEqual (new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05}, recreatedFrame.PayloadData);
                 
                 Assert.AreEqual (fcs, recreatedFrame.FrameCheckSequence);
             }
@@ -161,7 +161,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				DataDataFrame frame = new DataDataFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/DeauthenticationFrameTest.cs
+++ b/Test/PacketType/Ieee80211/DeauthenticationFrameTest.cs
@@ -123,7 +123,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				DeauthenticationFrame frame = new DeauthenticationFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/DisassociationFrameTest.cs
+++ b/Test/PacketType/Ieee80211/DisassociationFrameTest.cs
@@ -122,7 +122,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				DisassociationFrame frame = new DisassociationFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/MacFrameTest.cs
+++ b/Test/PacketType/Ieee80211/MacFrameTest.cs
@@ -121,7 +121,7 @@ namespace Test.PacketType
                 dataFrame.BssId = PhysicalAddress.Parse("AABBCCDDEEFF");
                 dataFrame.SourceAddress = PhysicalAddress.Parse("AABBCCDDEEFF");
                 dataFrame.DestinationAddress = PhysicalAddress.Parse("112233445566");
-                dataFrame.PayloadData = new byte[]{0x1, 0x2, 0x3, 0x4};
+                dataFrame.PayloadData = new Byte[]{0x1, 0x2, 0x3, 0x4};
                 
                 //Force it to recalculate the FCS and include it when serialised
                 dataFrame.UpdateFrameCheckSequence();
@@ -130,7 +130,7 @@ namespace Test.PacketType
                 
                 var expectedLength = dataFrame.FrameSize + dataFrame.PayloadData.Length + 4;
                 
-                byte[] frameBytes = dataFrame.Bytes;
+                Byte[] frameBytes = dataFrame.Bytes;
                 
                 Assert.AreEqual(expectedLength, frameBytes.Length);
                 Assert.AreEqual(dataFrame.FrameCheckSequence.ToString("X"),
@@ -150,7 +150,7 @@ namespace Test.PacketType
                 dataFrame.BssId = PhysicalAddress.Parse("AABBCCDDEEFF");
                 dataFrame.SourceAddress = PhysicalAddress.Parse("AABBCCDDEEFF");
                 dataFrame.DestinationAddress = PhysicalAddress.Parse("112233445566");
-                dataFrame.PayloadData = new byte[]{0x01, 0x02, 0x03, 0x04};
+                dataFrame.PayloadData = new Byte[]{0x01, 0x02, 0x03, 0x04};
                 
                 //Force it to recalculate the FCS but don't include it when serialised
                 dataFrame.UpdateFrameCheckSequence();

--- a/Test/PacketType/Ieee80211/NullDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/NullDataFrameTest.cs
@@ -89,7 +89,7 @@ namespace Test.PacketType
                 frame.SourceAddress = PhysicalAddress.Parse ("222222222222");
                 frame.BssId = PhysicalAddress.Parse ("333333333333");
                 
-                frame.PayloadData = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+                frame.PayloadData = new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
                 
                 frame.AppendFcs = true;
                 frame.UpdateFrameCheckSequence ();
@@ -121,7 +121,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				NullDataFrame frame = new NullDataFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/PerPacketInformationTest.cs
+++ b/Test/PacketType/Ieee80211/PerPacketInformationTest.cs
@@ -57,7 +57,7 @@ namespace Test.PacketType
                 Assert.IsTrue ((commonField.Flags & PpiCommon.CommonFlags.FcsIncludedInFrame) == PpiCommon.CommonFlags.FcsIncludedInFrame);
                 Assert.AreEqual (2, commonField.Rate);
                 Assert.AreEqual (2437, commonField.ChannelFrequency);
-                Assert.AreEqual (0x00A0, (int) commonField.ChannelFlags);
+                Assert.AreEqual (0x00A0, (Int32) commonField.ChannelFlags);
                 Assert.AreEqual (0, commonField.FhssHopset);
                 Assert.AreEqual (0, commonField.FhssPattern);
                 Assert.AreEqual (-84, commonField.AntennaSignalPower);
@@ -291,7 +291,7 @@ namespace Test.PacketType
                 
                 PpiPacket p = Packet.ParsePacket (rawCapture.LinkLayerType, rawCapture.Data) as PpiPacket;
                 
-                PpiUnknown unknownField = new PpiUnknown(99, new byte[]{0xAA, 0xBB, 0xCC, 0xDD});
+                PpiUnknown unknownField = new PpiUnknown(99, new Byte[]{0xAA, 0xBB, 0xCC, 0xDD});
                 p.Add(unknownField);
 
                 PpiPacket recreatedPacket = Packet.ParsePacket(LinkLayers.PerPacketInformation, p.Bytes) as PpiPacket;
@@ -300,7 +300,7 @@ namespace Test.PacketType
                 Assert.IsTrue(recreatedPacket.Contains(PpiFieldType.PpiMacPhy));
                 Assert.IsTrue(recreatedPacket.Contains((PpiFieldType)99));
                 PpiUnknown recreatedUnknownField = recreatedPacket.FindFirstByType((PpiFieldType)99) as PpiUnknown;
-                Assert.AreEqual(new byte[]{0xAA, 0xBB, 0xCC, 0xDD}, recreatedUnknownField.UnknownBytes);
+                Assert.AreEqual(new Byte[]{0xAA, 0xBB, 0xCC, 0xDD}, recreatedUnknownField.UnknownBytes);
                 
                 MacFrame macFrame = recreatedPacket.PayloadPacket as MacFrame;
                 Assert.IsNotNull(macFrame);

--- a/Test/PacketType/Ieee80211/PpiFieldsTests.cs
+++ b/Test/PacketType/Ieee80211/PpiFieldsTests.cs
@@ -178,13 +178,13 @@ namespace Test.PacketType
             [Test]
             public void Test_PpiUnknown_Construction()
             {
-                PpiUnknown field = new PpiUnknown(0xAA, new byte[]{0x1, 0x2, 0x3, 0x4});
+                PpiUnknown field = new PpiUnknown(0xAA, new Byte[]{0x1, 0x2, 0x3, 0x4});
                 
                 var ms = new MemoryStream(field.Bytes);
                 PpiUnknown recreatedField = new PpiUnknown(0xAA, new BinaryReader(ms), 4);
                 
-                Assert.AreEqual(0xAA, (int)recreatedField.FieldType);
-                Assert.AreEqual(new byte[]{0x1, 0x2, 0x3, 0x4}, recreatedField.Bytes);
+                Assert.AreEqual(0xAA, (Int32)recreatedField.FieldType);
+                Assert.AreEqual(new Byte[]{0x1, 0x2, 0x3, 0x4}, recreatedField.Bytes);
             }
             
             [Test]
@@ -197,7 +197,7 @@ namespace Test.PacketType
                 field.AmplitudeOffset = 0x98765432;
                 field.AmplitudeResolution = 0x11223344;
                 field.MaximumRssi = 0xAABB;
-                field.SamplesData = new byte[]{ 0xCC, 0xDD, 0xEE, 0xFF };
+                field.SamplesData = new Byte[]{ 0xCC, 0xDD, 0xEE, 0xFF };
                 
                 var ms = new MemoryStream(field.Bytes);
                 PpiSpectrum recreatedField = new PpiSpectrum(new BinaryReader(ms));
@@ -207,7 +207,7 @@ namespace Test.PacketType
                 Assert.AreEqual(0x98765432, recreatedField.AmplitudeOffset);
                 Assert.AreEqual(0x11223344, recreatedField.AmplitudeResolution);
                 Assert.AreEqual(0xAABB, recreatedField.MaximumRssi);
-                Assert.AreEqual(new byte[]{ 0xCC, 0xDD, 0xEE, 0xFF }, recreatedField.SamplesData);
+                Assert.AreEqual(new Byte[]{ 0xCC, 0xDD, 0xEE, 0xFF }, recreatedField.SamplesData);
             }
         }       
     }           

--- a/Test/PacketType/Ieee80211/ProbeRequestTest.cs
+++ b/Test/PacketType/Ieee80211/ProbeRequestTest.cs
@@ -127,7 +127,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				ProbeRequestFrame frame = new ProbeRequestFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/ProbeResponseTest.cs
+++ b/Test/PacketType/Ieee80211/ProbeResponseTest.cs
@@ -147,7 +147,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				ProbeResponseFrame frame = new ProbeResponseFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/QosDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/QosDataFrameTest.cs
@@ -116,7 +116,7 @@ namespace Test.PacketType
                 frame.SourceAddress = PhysicalAddress.Parse ("222222222222");
                 frame.BssId = PhysicalAddress.Parse ("333333333333");
                 
-                frame.PayloadData = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+                frame.PayloadData = new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
                 
                 frame.UpdateFrameCheckSequence ();
                 UInt32 fcs = frame.FrameCheckSequence;
@@ -142,7 +142,7 @@ namespace Test.PacketType
                 Assert.AreEqual ("222222222222", recreatedFrame.SourceAddress.ToString ().ToUpper ());
                 Assert.AreEqual ("333333333333", recreatedFrame.BssId.ToString ().ToUpper ());
                 
-                CollectionAssert.AreEqual (new byte[]{0x01, 0x02, 0x03, 0x04, 0x05}, recreatedFrame.PayloadData);
+                CollectionAssert.AreEqual (new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05}, recreatedFrame.PayloadData);
                 
                 Assert.AreEqual (fcs, recreatedFrame.FrameCheckSequence);
             }
@@ -151,7 +151,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				QosDataFrame frame = new QosDataFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/QosNullDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/QosNullDataFrameTest.cs
@@ -92,7 +92,7 @@ namespace Test.PacketType
                 frame.SourceAddress = PhysicalAddress.Parse ("222222222222");
                 frame.BssId = PhysicalAddress.Parse ("333333333333");
                 
-                frame.PayloadData = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+                frame.PayloadData = new Byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
                 
                 frame.AppendFcs= true;
                 frame.UpdateFrameCheckSequence ();
@@ -126,7 +126,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				QosNullDataFrame frame = new QosNullDataFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/Ieee80211/RadioPacketTest.cs
+++ b/Test/PacketType/Ieee80211/RadioPacketTest.cs
@@ -76,7 +76,7 @@ namespace Test.PacketType
                 
                 FlagsRadioTapField flagsField = p[RadioTapType.Flags] as FlagsRadioTapField;
                 Assert.IsNotNull(flagsField);
-                Assert.AreEqual(0, (int)flagsField.Flags);
+                Assert.AreEqual(0, (Int32)flagsField.Flags);
                 
                 RateRadioTapField rateField = p[RadioTapType.Rate] as RateRadioTapField;
                 Assert.IsNotNull(rateField);
@@ -143,7 +143,7 @@ namespace Test.PacketType
                 
                 //we will just put a single byte of data because we dont want it to be parsed into 
                 //an 802.11 frame in this test
-                p.PayloadData = new byte[]{0xFF};
+                p.PayloadData = new Byte[]{0xFF};
                 
                 var frameBytes = p.Bytes;
                 
@@ -152,7 +152,7 @@ namespace Test.PacketType
                 Assert.IsNotNull(p[RadioTapType.Flags]);
                 Assert.IsNotNull(p[RadioTapType.DbAntennaSignal]);
                 Assert.IsNotNull(p[RadioTapType.DbAntennaNoise]);
-                Assert.AreEqual(new byte[]{0xFF}, recreatedFrame.PayloadData);
+                Assert.AreEqual(new Byte[]{0xFF}, recreatedFrame.PayloadData);
             }
             
             
@@ -204,13 +204,13 @@ namespace Test.PacketType
             {
                 MemoryStream ms = new MemoryStream();
                 BinaryWriter bs = new BinaryWriter(ms);
-                bs.Write((byte)0x0); //version
-                bs.Write((byte)0x0); //pad
-                bs.Write((ushort) 0x0010); //length
-                bs.Write((uint) 0x80000002); //present 1 (wth flags field)
-                bs.Write((uint) 0x00010000); //present 2 (with unhandled field)
-                bs.Write((ushort) 0x0010); //Flags field (FCS included flag set)
-                bs.Write((ushort) 0x1234); //a made up field that we want to keep even though we dont know what it is
+                bs.Write((Byte)0x0); //version
+                bs.Write((Byte)0x0); //pad
+                bs.Write((UInt16) 0x0010); //length
+                bs.Write((UInt32) 0x80000002); //present 1 (wth flags field)
+                bs.Write((UInt32) 0x00010000); //present 2 (with unhandled field)
+                bs.Write((UInt16) 0x0010); //Flags field (FCS included flag set)
+                bs.Write((UInt16) 0x1234); //a made up field that we want to keep even though we dont know what it is
                 
                 var dev = new CaptureFileReaderDevice("../../CaptureFiles/80211_plus_radiotap_header.pcap");
                 dev.Open();

--- a/Test/PacketType/Ieee80211/RadioTapFieldsTest.cs
+++ b/Test/PacketType/Ieee80211/RadioTapFieldsTest.cs
@@ -13,7 +13,7 @@ namespace Test.PacketType.Ieee80211
         {
             ChannelRadioTapField field = new ChannelRadioTapField(2142, RadioTapChannelFlags.Channel2Ghz | RadioTapChannelFlags.Ofdm);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             ChannelRadioTapField recreatedField = new ChannelRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -28,7 +28,7 @@ namespace Test.PacketType.Ieee80211
         {
             FhssRadioTapField field = new FhssRadioTapField(5, 6);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             FhssRadioTapField recreatedField = new FhssRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -42,7 +42,7 @@ namespace Test.PacketType.Ieee80211
         {
             FlagsRadioTapField field = new FlagsRadioTapField(RadioTapFlags.ShortPreamble | RadioTapFlags.WepEncrypted);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             FlagsRadioTapField recreatedField = new FlagsRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -55,7 +55,7 @@ namespace Test.PacketType.Ieee80211
         {
             RateRadioTapField field = new RateRadioTapField(2);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             RateRadioTapField recreatedField = new RateRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -68,7 +68,7 @@ namespace Test.PacketType.Ieee80211
         {
             DbAntennaSignalRadioTapField field = new DbAntennaSignalRadioTapField(0x12);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             DbAntennaSignalRadioTapField recreatedField = new DbAntennaSignalRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -81,7 +81,7 @@ namespace Test.PacketType.Ieee80211
         {
             DbAntennaNoiseRadioTapField field = new DbAntennaNoiseRadioTapField(0xAB);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             DbAntennaNoiseRadioTapField recreatedField = new DbAntennaNoiseRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -94,7 +94,7 @@ namespace Test.PacketType.Ieee80211
         {
             AntennaRadioTapField field = new AntennaRadioTapField(0xAB);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             AntennaRadioTapField recreatedField = new AntennaRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -107,7 +107,7 @@ namespace Test.PacketType.Ieee80211
         {
             DbmAntennaSignalRadioTapField field = new DbmAntennaSignalRadioTapField(-128);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             DbmAntennaSignalRadioTapField recreatedField = new DbmAntennaSignalRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -120,7 +120,7 @@ namespace Test.PacketType.Ieee80211
         {
             DbmAntennaNoiseRadioTapField field = new DbmAntennaNoiseRadioTapField(127);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             DbmAntennaNoiseRadioTapField recreatedField = new DbmAntennaNoiseRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -133,7 +133,7 @@ namespace Test.PacketType.Ieee80211
         {
             LockQualityRadioTapField field = new LockQualityRadioTapField(0x1234);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             LockQualityRadioTapField recreatedField = new LockQualityRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -146,7 +146,7 @@ namespace Test.PacketType.Ieee80211
         {
             TsftRadioTapField field = new TsftRadioTapField(0x12345678);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             TsftRadioTapField recreatedField = new TsftRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -159,7 +159,7 @@ namespace Test.PacketType.Ieee80211
         {
             RxFlagsRadioTapField field = new RxFlagsRadioTapField(true);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             RxFlagsRadioTapField recreatedField = new RxFlagsRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -172,7 +172,7 @@ namespace Test.PacketType.Ieee80211
         {
             TxAttenuationRadioTapField field = new TxAttenuationRadioTapField(-4321);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             TxAttenuationRadioTapField recreatedField = new TxAttenuationRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -185,7 +185,7 @@ namespace Test.PacketType.Ieee80211
         {
             DbTxAttenuationRadioTapField field = new DbTxAttenuationRadioTapField(-1234);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             DbTxAttenuationRadioTapField recreatedField = new DbTxAttenuationRadioTapField(new BinaryReader (new MemoryStream(bytes)));
@@ -198,7 +198,7 @@ namespace Test.PacketType.Ieee80211
         {
             DbmTxPowerRadioTapField field = new DbmTxPowerRadioTapField(100);
             
-            var bytes = new byte[field.Length];
+            var bytes = new Byte[field.Length];
             field.CopyTo(bytes, 0);
             
             DbmTxPowerRadioTapField recreatedField = new DbmTxPowerRadioTapField(new BinaryReader (new MemoryStream(bytes)));

--- a/Test/PacketType/Ieee80211/ReassociationRequestFrameTest.cs
+++ b/Test/PacketType/Ieee80211/ReassociationRequestFrameTest.cs
@@ -139,7 +139,7 @@ namespace Test.PacketType
 			public void Test_ConstructorWithCorruptBuffer ()
 			{
 				//buffer is way too short for frame. We are just checking it doesn't throw
-				byte[] corruptBuffer = new byte[]{0x01};
+				Byte[] corruptBuffer = new Byte[]{0x01};
 				ReassociationRequestFrame frame = new ReassociationRequestFrame(new ByteArraySegment(corruptBuffer));
 				Assert.IsFalse(frame.FCSValid);
 			}

--- a/Test/PacketType/IpPacketTest.cs
+++ b/Test/PacketType/IpPacketTest.cs
@@ -104,7 +104,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundip = false;
+            Boolean foundip = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 Packet p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/LinktypeNullCaptureTest.cs
+++ b/Test/PacketType/LinktypeNullCaptureTest.cs
@@ -48,7 +48,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             while((rawCapture = dev.GetNextPacket()) != null)
             {
                 Console.WriteLine ("LinkLayerType: {0}", rawCapture.LinkLayerType);

--- a/Test/PacketType/LinuxCookedCaptureTest.cs
+++ b/Test/PacketType/LinuxCookedCaptureTest.cs
@@ -69,7 +69,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             while((rawCapture = dev.GetNextPacket()) != null)
             {
                 Packet p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/LldpTest.cs
+++ b/Test/PacketType/LldpTest.cs
@@ -38,21 +38,21 @@ namespace Test.PacketType
         public void ConstructFromValues()
         {
             var expectedChassisIDType = ChassisSubTypes.NetworkAddress;
-            var expectedChassisIDNetworkAddress = new NetworkAddress(new IPAddress(new byte[4] { 0x0A, 0x00, 0x01, 0x01 }));
-            var expectedPortIDBytes = new byte[15] { 0x30, 0x30, 0x31, 0x42, 0x35, 0x34, 0x39, 0x34, 0x35, 0x41, 0x38, 0x42, 0x3a, 0x50, 0x32 };
-            ushort expectedTimeToLive = 120;
-            string expectedPortDescription = "Port Description";
-            string expectedSystemName = "SystemName";
-            string expectedSystemDescription = "System Description";
-            ushort expectedSystemCapabilitiesCapability = 18;
-            ushort expectedSystemCapabilitiesEnabled = 16;
-            var managementAddressNetworkAddress = new NetworkAddress(new IPAddress(new byte[4] { 0x0A, 0x00, 0x01, 0x01 }));
+            var expectedChassisIDNetworkAddress = new NetworkAddress(new IPAddress(new Byte[4] { 0x0A, 0x00, 0x01, 0x01 }));
+            var expectedPortIDBytes = new Byte[15] { 0x30, 0x30, 0x31, 0x42, 0x35, 0x34, 0x39, 0x34, 0x35, 0x41, 0x38, 0x42, 0x3a, 0x50, 0x32 };
+            UInt16 expectedTimeToLive = 120;
+            String expectedPortDescription = "Port Description";
+            String expectedSystemName = "SystemName";
+            String expectedSystemDescription = "System Description";
+            UInt16 expectedSystemCapabilitiesCapability = 18;
+            UInt16 expectedSystemCapabilitiesEnabled = 16;
+            var managementAddressNetworkAddress = new NetworkAddress(new IPAddress(new Byte[4] { 0x0A, 0x00, 0x01, 0x01 }));
             var managementAddressObjectIdentifier = "Object Identifier";
-            uint managementAddressInterfaceNumber = 0x44060124;
+            UInt32 managementAddressInterfaceNumber = 0x44060124;
 
-            var expectedOrganizationUniqueIdentifier = new byte[3] { 0x24, 0x10, 0x12 };
+            var expectedOrganizationUniqueIdentifier = new Byte[3] { 0x24, 0x10, 0x12 };
             var expectedOrganizationSubType = 2;
-            var expectedOrganizationSpecificBytes = new byte[4] { 0xBA, 0xAD, 0xF0, 0x0D };
+            var expectedOrganizationSpecificBytes = new Byte[4] { 0xBA, 0xAD, 0xF0, 0x0D };
 
             var valuesLLDPPacket = new LLDPPacket();
             Console.WriteLine("valuesLLDPPacket.ToString() {0}", valuesLLDPPacket.ToString());
@@ -83,10 +83,10 @@ namespace Test.PacketType
 
             Console.WriteLine("lldpPacket.ToString() {0}", lldpPacket.ToString());
 
-            int expectedTlvCount = 10;
+            Int32 expectedTlvCount = 10;
             Assert.AreEqual(expectedTlvCount, lldpPacket.TlvCollection.Count);
 
-            int count = 1;
+            Int32 count = 1;
             foreach (TLV tlv in lldpPacket.TlvCollection)
             {
                 Console.WriteLine("Type: " + tlv.GetType().ToString());
@@ -145,7 +145,7 @@ namespace Test.PacketType
                         Assert.AreEqual(managementAddressNetworkAddress, mgmtAdd.MgmtAddress);
                         Assert.AreEqual(InterfaceNumbering.SystemPortNumber, mgmtAdd.InterfaceSubType);
                         Assert.AreEqual(managementAddressInterfaceNumber, mgmtAdd.InterfaceNumber);
-                        int expectedObjIdLength = managementAddressObjectIdentifier.Length;
+                        Int32 expectedObjIdLength = managementAddressObjectIdentifier.Length;
                         Assert.AreEqual(expectedObjIdLength, mgmtAdd.ObjIdLength);
                         Assert.AreEqual(managementAddressObjectIdentifier, mgmtAdd.ObjectIdentifier);
                         break;
@@ -181,7 +181,7 @@ namespace Test.PacketType
             Console.WriteLine("Parsing");
             var l = (LLDPPacket)p.Extract(typeof(LLDPPacket));
 
-            int count = 1;
+            Int32 count = 1;
             Console.WriteLine(l.TlvCollection.Count.ToString());
             foreach (TLV tlv in l.TlvCollection)
             {
@@ -193,14 +193,14 @@ namespace Test.PacketType
                         var chassisID = (ChassisID)tlv;
                         Assert.AreEqual(chassisID.SubType, ChassisSubTypes.NetworkAddress);
                         Assert.AreEqual(typeof(NetworkAddress), chassisID.SubTypeValue.GetType());
-                        var testAddress = new NetworkAddress(new IPAddress(new byte[4] { 0xac, 0x10, 0x0a, 0x6d }));
+                        var testAddress = new NetworkAddress(new IPAddress(new Byte[4] { 0xac, 0x10, 0x0a, 0x6d }));
                         Assert.AreEqual(testAddress, chassisID.SubTypeValue);
                         break;
                     case 2:
                         Assert.AreEqual(typeof(PortID), tlv.GetType());
                         var portID = (PortID)tlv;
                         Assert.AreEqual(PortSubTypes.LocallyAssigned, portID.SubType);
-                        byte[] subTypeValue = new byte[15] { 0x30, 0x30, 0x31, 0x42, 0x35, 0x34, 0x39, 0x34, 0x35, 0x41, 0x38, 0x42, 0x3a, 0x50, 0x32 };
+                        Byte[] subTypeValue = new Byte[15] { 0x30, 0x30, 0x31, 0x42, 0x35, 0x34, 0x39, 0x34, 0x35, 0x41, 0x38, 0x42, 0x3a, 0x50, 0x32 };
                         Assert.AreEqual(subTypeValue, portID.SubTypeValue);
                         break;
                     case 3:
@@ -233,19 +233,19 @@ namespace Test.PacketType
                         Assert.AreEqual(typeof(ManagementAddress), tlv.GetType());
                         var managementAddress = (ManagementAddress)tlv;
                         Assert.AreEqual(5, managementAddress.AddressLength);
-                        Assert.AreEqual(1, (int)managementAddress.AddressSubType);
-                        var mgmtAddress = new NetworkAddress(new IPAddress(new byte[4] { 0xac, 0x10, 0x0a, 0x6d }));
+                        Assert.AreEqual(1, (Int32)managementAddress.AddressSubType);
+                        var mgmtAddress = new NetworkAddress(new IPAddress(new Byte[4] { 0xac, 0x10, 0x0a, 0x6d }));
                         Assert.AreEqual(mgmtAddress, managementAddress.MgmtAddress);
-                        Assert.AreEqual(1, (int)managementAddress.InterfaceSubType);
+                        Assert.AreEqual(1, (Int32)managementAddress.InterfaceSubType);
                         Assert.AreEqual(0, managementAddress.InterfaceNumber);
                         Assert.AreEqual(0, managementAddress.ObjIdLength);
                         break;
                     case 9:
                         Assert.AreEqual(typeof(OrganizationSpecific), tlv.GetType());
                         var organizationSpecific = (OrganizationSpecific)tlv;
-                        Assert.AreEqual(new byte[3] { 0x00, 0x12, 0x0f }, organizationSpecific.OrganizationUniqueID);
+                        Assert.AreEqual(new Byte[3] { 0x00, 0x12, 0x0f }, organizationSpecific.OrganizationUniqueID);
                         Assert.AreEqual(1, organizationSpecific.OrganizationDefinedSubType);
-                        byte[] infoString = new byte[5] { 0x03, 0x00, 0x36, 0x00, 0x10 };
+                        Byte[] infoString = new Byte[5] { 0x03, 0x00, 0x36, 0x00, 0x10 };
                         Assert.AreEqual(infoString, organizationSpecific.OrganizationDefinedInfoString);
                         break;
                     case 10:
@@ -306,7 +306,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundlldp = false;
+            Boolean foundlldp = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 Packet p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);
@@ -335,7 +335,7 @@ namespace Test.PacketType
                 Assert.AreEqual(lldp.Header, fromFile.Header);
                 Assert.AreEqual(lldp.PayloadData, fromFile.PayloadData);
 
-                for (int i = 0; i < lldp.TlvCollection.Count; i++)
+                for (Int32 i = 0; i < lldp.TlvCollection.Count; i++)
                 {
                     Assert.AreEqual(lldp.TlvCollection[i].Bytes, fromFile.TlvCollection[i].Bytes);
                     Assert.AreEqual(lldp.TlvCollection[i].Length, fromFile.TlvCollection[i].Length);
@@ -347,7 +347,7 @@ namespace Test.PacketType
                 //Method Invocations to make sure that a deserialized packet does not cause 
                 //additional errors.
 
-                lldp.ParseByteArrayIntoTlvs(new byte[] { 0, 0 }, 0);
+                lldp.ParseByteArrayIntoTlvs(new Byte[] { 0, 0 }, 0);
                 lldp.PrintHex();
                 lldp.UpdateCalculatedValues();
             }

--- a/Test/PacketType/OSPFv2PacketTest.cs
+++ b/Test/PacketType/OSPFv2PacketTest.cs
@@ -11,13 +11,13 @@ namespace Test.PacketType
     [TestFixture]
     class OSPFv2PacketTest
     {
-        private const int OSPF_HELLO_INDEX = 0;
-        private const int OSPF_DBD_INDEX = 9;
-        private const int OSPF_DBD_LSA_INDEX = 11;
-        private const int OSPF_LSR_INDEX = 17;
-        private const int OSPF_LSU_INDEX = 18;
-        private const int OSPF_LSA_INDEX = 23;
-        private const int OSPF_LSU_LSA_INDEX = 31;
+        private const Int32 OSPF_HELLO_INDEX = 0;
+        private const Int32 OSPF_DBD_INDEX = 9;
+        private const Int32 OSPF_DBD_LSA_INDEX = 11;
+        private const Int32 OSPF_LSR_INDEX = 17;
+        private const Int32 OSPF_LSU_INDEX = 18;
+        private const Int32 OSPF_LSA_INDEX = 23;
+        private const Int32 OSPF_LSU_LSA_INDEX = 31;
 
         OSPFv2Packet helloPacket;
         OSPFv2Packet ddPacket;
@@ -28,7 +28,7 @@ namespace Test.PacketType
 
         OSPFv2LSUpdatePacket lsaHolder;
 
-        bool packetsLoaded = false;
+        Boolean packetsLoaded = false;
 
         [SetUp]
         public void Init()
@@ -37,7 +37,7 @@ namespace Test.PacketType
                 return;
 
             RawCapture raw;
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             var dev = new CaptureFileReaderDevice("../../CaptureFiles/ospfv2.pcap");
             dev.Open();
 
@@ -582,7 +582,7 @@ namespace Test.PacketType
             RawCapture raw;
             var dev = new CaptureFileReaderDevice("../../CaptureFiles/ospfv2_md5.pcap");
             OSPFv2HelloPacket[] testSubjects = new OSPFv2HelloPacket[4];
-            int i = 0;
+            Int32 i = 0;
 
             dev.Open();
             while ((raw = dev.GetNextPacket()) != null && i < 4)
@@ -592,10 +592,10 @@ namespace Test.PacketType
             }
             dev.Close();
 
-            Assert.AreEqual(testSubjects[0].Authentication, (long)0x000000103c7ec4f7);
-            Assert.AreEqual(testSubjects[1].Authentication, (long)0x000000103c7ec4fc);
-            Assert.AreEqual(testSubjects[2].Authentication, (long)0x000000103c7ec501);
-            Assert.AreEqual(testSubjects[3].Authentication, (long)0x000000103c7ec505);
+            Assert.AreEqual(testSubjects[0].Authentication, (Int64)0x000000103c7ec4f7);
+            Assert.AreEqual(testSubjects[1].Authentication, (Int64)0x000000103c7ec4fc);
+            Assert.AreEqual(testSubjects[2].Authentication, (Int64)0x000000103c7ec501);
+            Assert.AreEqual(testSubjects[3].Authentication, (Int64)0x000000103c7ec505);
             Assert.AreEqual(0, testSubjects[0].NeighborID.Count);
             Assert.AreEqual(0, testSubjects[1].NeighborID.Count);
             Assert.AreEqual(1, testSubjects[2].NeighborID.Count);
@@ -630,7 +630,7 @@ namespace Test.PacketType
             Assert.AreEqual(0, p.NeighborID.Count);
 
             //test re-creation
-            byte[] bytes = p.Bytes;
+            Byte[] bytes = p.Bytes;
             OSPFv2HelloPacket hp = new OSPFv2HelloPacket(new ByteArraySegment(bytes));
 
             Assert.AreEqual(OSPFVersion.OSPFv2, hp.Version);
@@ -677,7 +677,7 @@ namespace Test.PacketType
             Assert.AreEqual(0x02, d.DBDescriptionOptions);
 
             //test re-creation
-            byte[] bytes = d.Bytes;
+            Byte[] bytes = d.Bytes;
             OSPFv2DDPacket dp = new OSPFv2DDPacket(new ByteArraySegment(bytes));
 
             Assert.AreEqual(OSPFPacketType.DatabaseDescription, d.Type);
@@ -765,7 +765,7 @@ namespace Test.PacketType
             Assert.AreEqual(System.Net.IPAddress.Parse("192.168.255.252"), p.AreaID);
 
             //test re-creation
-            byte[] bytes = p.Bytes;
+            Byte[] bytes = p.Bytes;
             OSPFv2LSRequestPacket lp = new OSPFv2LSRequestPacket(new ByteArraySegment(bytes));
 
             Assert.AreEqual(OSPFVersion.OSPFv2, lp.Version);
@@ -1127,7 +1127,7 @@ namespace Test.PacketType
             Assert.AreEqual(0, p.LSANumber);
 
             //test re-creation
-            byte[] bytes = p.Bytes;
+            Byte[] bytes = p.Bytes;
             OSPFv2LSUpdatePacket lp = new OSPFv2LSUpdatePacket(new ByteArraySegment(bytes));
 
             Assert.AreEqual(OSPFVersion.OSPFv2, lp.Version);
@@ -1344,7 +1344,7 @@ namespace Test.PacketType
             Assert.AreEqual(OSPFPacketType.LinkStateAcknowledgment, p.Type);
 
             //test re-creation
-            byte[] bytes = p.Bytes;
+            Byte[] bytes = p.Bytes;
             OSPFv2DDPacket p2 = new OSPFv2DDPacket(new ByteArraySegment(bytes));
 
             Assert.AreEqual(OSPFPacketType.LinkStateAcknowledgment, p2.Type);

--- a/Test/PacketType/PPPPacketTest.cs
+++ b/Test/PacketType/PPPPacketTest.cs
@@ -77,7 +77,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundPPP = false;
+            Boolean foundPPP = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 var p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/TcpPacketTest.cs
+++ b/Test/PacketType/TcpPacketTest.cs
@@ -61,7 +61,7 @@ namespace Test.PacketType
             // even though the packet has 6 bytes of extra data, the ip packet shows a size of
             // 40 and the ip header has a length of 20. The TCP header is also 20 bytes so
             // there should be zero bytes in the TCPData value
-            int expectedTcpDataLength = 0;
+            Int32 expectedTcpDataLength = 0;
             Assert.AreEqual(expectedTcpDataLength, t.PayloadData.Length);
 
             dev.Close();
@@ -92,7 +92,7 @@ namespace Test.PacketType
         public void PayloadModification()
         {
             String s = "-++++=== HELLLLOOO ===++++-";
-            byte[] data = System.Text.Encoding.UTF8.GetBytes(s);
+            Byte[] data = System.Text.Encoding.UTF8.GetBytes(s);
 
             //create random pkt
             var p = TcpPacket.RandomPacket();
@@ -139,7 +139,7 @@ namespace Test.PacketType
             Assert.IsNotNull(t, "Expected t to not be null");
 
             // verify that the options byte match what we expect
-            byte[] expectedOptions = new byte[] { 0x1, 0x1, 0x8, 0xa, 0x0, 0x14,
+            Byte[] expectedOptions = new Byte[] { 0x1, 0x1, 0x8, 0xa, 0x0, 0x14,
                                                   0x3d, 0xe5, 0x1d, 0xf5, 0xf8, 0x84 };
             Assert.AreEqual(expectedOptions, t.Options);
 
@@ -149,8 +149,8 @@ namespace Test.PacketType
         [Test]
         public void TCPConstructorFromValues()
         {
-            ushort sourcePort = 100;
-            ushort destinationPort = 101;
+            UInt16 sourcePort = 100;
+            UInt16 destinationPort = 101;
             var tcpPacket = new TcpPacket(sourcePort, destinationPort);
 
             Assert.AreEqual(sourcePort, tcpPacket.SourcePort);
@@ -203,7 +203,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundtcpPacket = false;
+            Boolean foundtcpPacket = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 var p = PacketDotNet.Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/UdpTest.cs
+++ b/Test/PacketType/UdpTest.cs
@@ -86,12 +86,12 @@ namespace Test.PacketType
         public void ConstructUdpPacketFromValuesAndCheckThatLengthIsUpdated()
         {
             // build a udp packet
-            ushort sourcePort = 200;
-            ushort destinationPort = 300;
-            byte[] dataBytes = new byte[32];
-            for(int i = 0; i < dataBytes.Length; i++)
+            UInt16 sourcePort = 200;
+            UInt16 destinationPort = 300;
+            Byte[] dataBytes = new Byte[32];
+            for(Int32 i = 0; i < dataBytes.Length; i++)
             {
-                dataBytes[i] = (byte)i;
+                dataBytes[i] = (Byte)i;
             }
 
             var udpPacket = new UdpPacket(sourcePort, destinationPort);
@@ -136,7 +136,7 @@ namespace Test.PacketType
             dev.Open();
 
             // checksums from wireshark of the capture file
-            int[] expectedChecksum = {0x2be9,
+            Int32[] expectedChecksum = {0x2be9,
                                       0x9e06,
                                       0xd279,
                                       0x4709,
@@ -147,7 +147,7 @@ namespace Test.PacketType
                                       0xb8e6,
                                       0x932c};
 
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             RawCapture rawCapture;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
@@ -174,9 +174,9 @@ namespace Test.PacketType
             dev.Open();
 
             // checksums from wireshark of the capture file
-            int[] expectedChecksum = {0x61fb};
+            Int32[] expectedChecksum = {0x61fb};
 
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             RawCapture rawCapture;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
@@ -239,7 +239,7 @@ namespace Test.PacketType
             dev.Open();
 
             RawCapture rawCapture;
-            bool foundudpPacket = false;
+            Boolean foundudpPacket = false;
             while ((rawCapture = dev.GetNextPacket()) != null)
             {
                 var p = PacketDotNet.Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/PacketType/WakeOnLanTest.cs
+++ b/Test/PacketType/WakeOnLanTest.cs
@@ -59,7 +59,7 @@ namespace Test.PacketType
 
             RawCapture rawCapture;
 
-            int packetIndex = 0;
+            Int32 packetIndex = 0;
             while((rawCapture = dev.GetNextPacket()) != null)
             {
                 var p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);

--- a/Test/Performance/BitConversionPerformance.cs
+++ b/Test/Performance/BitConversionPerformance.cs
@@ -40,16 +40,16 @@ namespace Test.Performance
             LoggingConfiguration.GlobalLoggingLevel = log4net.Core.Level.Off;
 
 
-            byte[] bytes;
-            int testRuns;
-            int startIndex;
-            int expectedValue;
+            Byte[] bytes;
+            Int32 testRuns;
+            Int32 startIndex;
+            Int32 expectedValue;
             ByteSetupMethods.Setup(out bytes, out testRuns, out startIndex,
                                    out expectedValue);
 
             var startTime = DateTime.Now;
 
-            for(int i = 0; i < testRuns; i++)
+            for(Int32 i = 0; i < testRuns; i++)
             {
                 var actualValue = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(bytes, startIndex));
 
@@ -82,10 +82,10 @@ namespace Test.Performance
             // disable logging to improve performance
             LoggingConfiguration.GlobalLoggingLevel = log4net.Core.Level.Off;
 
-            byte[] bytes;
-            int testRuns;
-            int startIndex;
-            int expectedValue;
+            Byte[] bytes;
+            Int32 testRuns;
+            Int32 startIndex;
+            Int32 expectedValue;
             ByteSetupMethods.Setup(out bytes, out testRuns, out startIndex,
                                    out expectedValue);
 
@@ -94,7 +94,7 @@ namespace Test.Performance
 
             var startTime = DateTime.Now;
 
-            for(int i = 0; i < testRuns; i++)
+            for(Int32 i = 0; i < testRuns; i++)
             {
                 endianReader.Seek(startIndex, SeekOrigin.Begin);
                 var actualValue = endianReader.ReadInt32();
@@ -128,16 +128,16 @@ namespace Test.Performance
             // disable logging to improve performance
             LoggingConfiguration.GlobalLoggingLevel = log4net.Core.Level.Off;
 
-            byte[] bytes;
-            int testRuns;
-            int startIndex;
-            int expectedValue;
+            Byte[] bytes;
+            Int32 testRuns;
+            Int32 startIndex;
+            Int32 expectedValue;
             ByteSetupMethods.Setup(out bytes, out testRuns, out startIndex,
                                    out expectedValue);
 
             var startTime = DateTime.Now;
 
-            for(int i = 0; i < testRuns; i++)
+            for(Int32 i = 0; i < testRuns; i++)
             {
                 var actualValue = MiscUtil.Conversion.EndianBitConverter.Big.ToInt32(bytes, startIndex);
 

--- a/Test/Performance/ByteCopyPerformance.cs
+++ b/Test/Performance/ByteCopyPerformance.cs
@@ -11,7 +11,7 @@ namespace Test.Performance
     public class ByteCopyPerformance
     {
         // The number of times the test is run
-        int testRuns = 40000;
+        Int32 testRuns = 40000;
 
         [Test]
         public void ArrayCopyPerformance()
@@ -19,7 +19,7 @@ namespace Test.Performance
             // create a realistic packet for testing
             var ethernetPacket = EthernetPacket.RandomPacket();
             // create the array to store the copy result
-            byte[] hwAddress = new byte[EthernetFields.MacAddressLength];
+            Byte[] hwAddress = new Byte[EthernetFields.MacAddressLength];
 
             // store the logging value
             var oldThreshold = LoggingConfiguration.GlobalLoggingLevel;
@@ -31,7 +31,7 @@ namespace Test.Performance
             var startTime = DateTime.Now;
 
             // run the test
-            for (int i = 0; i < testRuns; i++)
+            for (Int32 i = 0; i < testRuns; i++)
             {
                 Array.Copy(ethernetPacket.Bytes, EthernetFields.SourceMacPosition,
                     hwAddress, 0, EthernetFields.MacAddressLength);
@@ -56,7 +56,7 @@ namespace Test.Performance
             // create a realistic packet for testing
             var ethernetPacket = EthernetPacket.RandomPacket();
             // create the array to store the copy result
-            byte[] hwAddress = new byte[EthernetFields.MacAddressLength];
+            Byte[] hwAddress = new Byte[EthernetFields.MacAddressLength];
 
             // store the logging value
             var oldThreshold = LoggingConfiguration.GlobalLoggingLevel;
@@ -68,7 +68,7 @@ namespace Test.Performance
             var startTime = DateTime.Now;
 
             // run the test
-            for (int i = 0; i < testRuns; i++)
+            for (Int32 i = 0; i < testRuns; i++)
             {
                 Buffer.BlockCopy(ethernetPacket.Bytes, EthernetFields.SourceMacPosition,
                     hwAddress, 0, EthernetFields.MacAddressLength);

--- a/Test/Performance/ByteRetrievalPerformance.cs
+++ b/Test/Performance/ByteRetrievalPerformance.cs
@@ -59,7 +59,7 @@ namespace Test.Performance
 
             // used to make sure we get the same byte[] reference returned each time
             // because thats what we expect
-            byte[] theByteArray = null;
+            Byte[] theByteArray = null;
 
             // store the logging value
             var oldThreshold = LoggingConfiguration.GlobalLoggingLevel;
@@ -70,7 +70,7 @@ namespace Test.Performance
             // now benchmark retrieving the byte[] for several seconds
             var startTime = DateTime.Now;
             var endTime = startTime.Add(new TimeSpan(0, 0, 2));
-            int testRuns = 0;
+            Int32 testRuns = 0;
             while(DateTime.Now < endTime)
             {
                 var theBytes = contiguousEthernetPacket.Bytes;
@@ -104,7 +104,7 @@ namespace Test.Performance
         {
             var ethernetPacket = BuildNonContiguousEthernetPacket();
 
-            byte[] lastByteArray = null;
+            Byte[] lastByteArray = null;
 
             // store the logging value
             var oldThreshold = LoggingConfiguration.GlobalLoggingLevel;
@@ -115,7 +115,7 @@ namespace Test.Performance
             // now benchmark retrieving the byte[] for several seconds
             var startTime = DateTime.Now;
             var endTime = startTime.Add(new TimeSpan(0, 0, 2));
-            int testRuns = 0;
+            Int32 testRuns = 0;
             while(DateTime.Now < endTime)
             {
                 var theBytes = ethernetPacket.Bytes;

--- a/Test/Rate.cs
+++ b/Test/Rate.cs
@@ -8,11 +8,11 @@ namespace Test
     public class Rate
     {
         private TimeSpan Elapsed;
-        private string EventType;
-        private int EventCount;
+        private String EventType;
+        private Int32 EventCount;
 
         public Rate(DateTime Start, DateTime End,
-                    int EventCount, string EventType)
+                    Int32 EventCount, String EventType)
         {
             Elapsed = End - Start;
             this.EventCount = EventCount;
@@ -22,7 +22,7 @@ namespace Test
         /// <value>
         /// Returns the rate in terms of events per second
         /// </value>
-        public double RatePerSecond
+        public Double RatePerSecond
         {
             get
             {
@@ -30,7 +30,7 @@ namespace Test
             }
         }
 
-        public override string ToString ()
+        public override String ToString ()
         {
             return String.Format(" {0,10} {1} at a rate of {2,12} / second ({3} seconds elapsed)",
                                  EventCount,


### PR DESCRIPTION
For a network data related project it is much more readable to see exact type and its size, e.g., int -> Int32, ushort->UInt16.