### PR TITLE
Add ISourceDestinationPort to unify access to TCP and UDP ports.

### DIFF
--- a/PacketDotNet/AssemblyInfo.cs
+++ b/PacketDotNet/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Reflection;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("0.18.0")]
+[assembly: AssemblyVersion("0.18.1")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/PacketDotNet/ISourceDestinationPort.cs
+++ b/PacketDotNet/ISourceDestinationPort.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace PacketDotNet
+{
+  public interface ISourceDestinationPort
+  {
+    /// <summary> Fetch the port number on the target host.</summary>
+    UInt16 DestinationPort { get; set; }
+
+    /// <summary> Fetch the port number on the source host.</summary>
+    UInt16 SourcePort { get; set; }
+  }
+}

--- a/PacketDotNet/PacketDotNet.csproj
+++ b/PacketDotNet/PacketDotNet.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Version>0.18.0</Version>
+    <Version>0.18.1</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Copyright></Copyright>

--- a/PacketDotNet/TcpPacket.cs
+++ b/PacketDotNet/TcpPacket.cs
@@ -34,7 +34,7 @@ namespace PacketDotNet
     /// See: http://en.wikipedia.org/wiki/Transmission_Control_Protocol
     /// </summary>
     [Serializable]
-    public sealed class TcpPacket : TransportPacket
+    public sealed class TcpPacket : TransportPacket, ISourceDestinationPort
     {
 #if DEBUG
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);

--- a/PacketDotNet/UdpPacket.cs
+++ b/PacketDotNet/UdpPacket.cs
@@ -33,8 +33,8 @@ namespace PacketDotNet
     /// See http://en.wikipedia.org/wiki/Udp
     /// </summary>
     [Serializable]
-    public sealed class UdpPacket : TransportPacket
-    {
+    public sealed class UdpPacket : TransportPacket, ISourceDestinationPort
+  {
 #if DEBUG
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 #else


### PR DESCRIPTION
Add ISourceDestinationPort to unify access to TCP and UDP ports. It simplifies usage without a need to cast each packet to be particular type TCP or UDP. 