### PR TITLE
Fixed: PPPoe Version value and added Wake-On-Lan password field

### DIFF
--- a/PacketDotNet/PppoePacket.cs
+++ b/PacketDotNet/PppoePacket.cs
@@ -164,10 +164,9 @@ namespace PacketDotNet
         /// <summary>
         /// PPPoe version, must be 0x1 according to RFC
         /// </summary>
-        /// FIXME: This currently outputs the wrong version number
         public byte Version
         {
-            get => (byte) ((VersionType >> 4) & 0xF0);
+            get => (byte)((VersionType >> 4) & 0x0F);
             set
             {
                 var versionType = VersionType;

--- a/PacketDotNet/WakeOnLanFields.cs
+++ b/PacketDotNet/WakeOnLanFields.cs
@@ -37,9 +37,9 @@ namespace PacketDotNet
 
         /// <summary>Size of an Destination Address in bytes.</summary>
         public static readonly int DestinationAddressLength;
-        
+
         /// <summary>Number of times Destination Address is repeated in Wake-On-Lan.</summary>
-        public static readonly int MacAddressRepetition=16;
+        public static readonly int MacAddressRepetition = 16;
 
         /// <summary>Position of the Password within the Wake-On-Lan header.</summary>
         public static readonly int PasswordPosition;

--- a/PacketDotNet/WakeOnLanFields.cs
+++ b/PacketDotNet/WakeOnLanFields.cs
@@ -1,0 +1,54 @@
+﻿
+/*
+This file is part of PacketDotNet
+
+PacketDotNet is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+PacketDotNet is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ *  Copyright 2019 George Rahul<georgerahul143@gmail.com>
+ */
+
+namespace PacketDotNet
+{
+    /// <summary>
+    /// Wake-On-Lan protocol field encoding information.
+    /// </summary>
+    public struct WakeOnLanFields
+    {
+        /// <summary>Position of the Sync Sequence within the Wake-On-Lan header.</summary>
+        public static readonly int SyncSequencePosition = 0;
+
+        /// <summary>Size of an Sync Sequence in bytes.</summary>
+        public static readonly int SyncSequenceLength = 6;
+
+        /// <summary>Position of the Destination Address within the Wake-On-Lan header.</summary>
+        public static readonly int DestinationAddressPosition;
+
+        /// <summary>Size of an Destination Address in bytes.</summary>
+        public static readonly int DestinationAddressLength;
+        
+        /// <summary>Number of times Destination Address is repeated in Wake-On-Lan.</summary>
+        public static readonly int MacAddressRepetition=16;
+
+        /// <summary>Position of the Password within the Wake-On-Lan header.</summary>
+        public static readonly int PasswordPosition;
+
+        static WakeOnLanFields()
+        {
+            DestinationAddressPosition = SyncSequenceLength;
+            DestinationAddressLength = MacAddressRepetition * EthernetFields.MacAddressLength;
+            PasswordPosition = DestinationAddressPosition + DestinationAddressLength;
+        }
+    }
+}

--- a/PacketDotNet/WakeOnLanPacket.cs
+++ b/PacketDotNet/WakeOnLanPacket.cs
@@ -148,6 +148,37 @@ namespace PacketDotNet
                 }
                 return new byte[0];
             }
+            set
+            { 
+                var bytes = value;
+                var headerLength = WakeOnLanFields.PasswordPosition;
+                var newLength = headerLength + bytes.Length;
+                var prevValueLength = Password.Length;
+
+                //If Wake-On-Lan packet size is not matching, create a new ByteArraySegment.
+                if (bytes.Length != prevValueLength)
+                {
+
+                    // allocate new memory for this packet
+                    var newByte = new byte[newLength];
+
+                    // copy the header bytes over
+                    Array.Copy(Header.Bytes, Header.Offset,
+                               newByte, 0,
+                               headerLength);
+
+                    Header = new ByteArraySegment(newByte, 0, newLength);
+                }
+
+                // copy the byte array in
+                if (bytes.Length == 6 || bytes.Length == 4)
+                {
+                    // set the password
+                    Array.Copy(bytes, 0,
+                           Header.Bytes, Header.Offset + headerLength,
+                           bytes.Length);
+                }
+            }
         }
 
         /// <summary>

--- a/PacketDotNet/WakeOnLanPacket.cs
+++ b/PacketDotNet/WakeOnLanPacket.cs
@@ -149,34 +149,22 @@ namespace PacketDotNet
                 return new byte[0];
             }
             set
-            { 
+            {
                 var bytes = value;
                 var headerLength = WakeOnLanFields.PasswordPosition;
-                var newLength = headerLength + bytes.Length;
-                var prevValueLength = Password.Length;
-
-                //If Wake-On-Lan packet size is not matching, create a new ByteArraySegment.
-                if (bytes.Length != prevValueLength)
-                {
-
-                    // allocate new memory for this packet
-                    var newByte = new byte[newLength];
-
-                    // copy the header bytes over
-                    Array.Copy(Header.Bytes, Header.Offset,
-                               newByte, 0,
-                               headerLength);
-
-                    Header = new ByteArraySegment(newByte, 0, newLength);
-                }
-
-                // copy the byte array in
+                
+                // checks if the new value matches with the specification.
                 if (bytes.Length == 6 || bytes.Length == 4)
                 {
-                    // set the password
-                    Array.Copy(bytes, 0,
-                           Header.Bytes, Header.Offset + headerLength,
-                           bytes.Length);
+                    // checks if the byte can fit the current byteArraySegment.
+                    if (bytes.Length == Password.Length)
+                    {
+                        // set the password
+                        Array.Copy(bytes, 0,
+                               Header.Bytes, Header.Offset + WakeOnLanFields.PasswordPosition,
+                               bytes.Length);
+
+                    }
                 }
             }
         }

--- a/Test/PacketType/WakeOnLanTest.cs
+++ b/Test/PacketType/WakeOnLanTest.cs
@@ -119,5 +119,37 @@ namespace Test.PacketType
 
             dev.Close();
         }
+
+        [Test]
+        public void PasswordChecking()
+        {
+            var dev = new CaptureFileReaderDevice(NUnitSetupClass.CaptureDirectory + "wol.pcap");
+            dev.Open();
+
+            RawCapture rawCapture;
+
+            var packetIndex = 0;
+            while ((rawCapture = dev.GetNextPacket()) != null)
+            {
+                var p = Packet.ParsePacket(rawCapture.LinkLayerType, rawCapture.Data);
+                Assert.IsNotNull(p);
+
+                var wol = p.Extract<WakeOnLanPacket>();
+                Assert.IsNotNull(p);
+
+                if (packetIndex == 0|| packetIndex == 3)
+                    Assert.AreEqual(wol.Password, new byte[0]);
+
+                if (packetIndex == 1)
+                    Assert.AreEqual(wol.Password, new byte[] { 0xc0, 0xa8, 0x01, 0x01 });
+
+                if (packetIndex == 2)
+                    Assert.AreEqual(wol.Password, new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab });
+                
+                packetIndex++;
+            }
+
+            dev.Close();
+        }
     }
 }


### PR DESCRIPTION
* PPPoe Version field getter code was using the wrong mask. It if fixed.

* Added Password field for Wake on Lan. The value is returned as a string. No setter available for the field.