### PR TITLE
Relicensing from LGPL v3 to MPL 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,165 +1,373 @@
-		   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+Mozilla Public License Version 2.0
+==================================
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+1. Definitions
+--------------
 
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
 
-  0. Additional Definitions.
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
+1.5. "Incompatible With Secondary Licenses"
+    means
 
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
 
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
 
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
 
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
 
-  1. Exception to Section 3 of the GNU GPL.
+1.8. "License"
+    means this document.
 
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
 
-  2. Conveying Modified Versions.
+1.10. "Modifications"
+    means any of the following:
 
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
 
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
 
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
 
-  3. Object Code Incorporating Material from Library Header Files.
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
 
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
 
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
 
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
+2. License Grants and Conditions
+--------------------------------
 
-  4. Combined Works.
+2.1. Grants
 
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
 
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
 
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
 
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
+2.2. Effective Date
 
-   d) Do one of the following:
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
 
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
+2.3. Limitations on Grant Scope
 
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
 
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
+(a) for any code that a Contributor has removed from Covered Software;
+    or
 
-  5. Combined Libraries.
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
 
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
 
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
 
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
+2.4. Subsequent Licenses
 
-  6. Revised Versions of the GNU Lesser General Public License.
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
 
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
+2.5. Representation
 
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
 
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/PacketDotNet.nuspec
+++ b/PacketDotNet.nuspec
@@ -5,7 +5,7 @@
         <version>1.1.1</version>
         <authors>Chris Morgan</authors>
 	      <owners>chmorgan</owners>
-        <licenseUrl>https://www.gnu.org/licenses/lgpl-3.0.en.html/</licenseUrl>
+        <licenseUrl>https://www.mozilla.org/en-US/MPL/2.0/</licenseUrl>
         <projectUrl>https://github.com/chmorgan/packetnet</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>High performance .Net assembly for dissecting and constructing network packets such as ethernet, ip, tcp, udp etc.</description>

--- a/PacketDotNet/ArpFields.cs
+++ b/PacketDotNet/ArpFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/ArpFields.cs
+++ b/PacketDotNet/ArpFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/ArpOperation.cs
+++ b/PacketDotNet/ArpOperation.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/ArpOperation.cs
+++ b/PacketDotNet/ArpOperation.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/ArpPacket.cs
+++ b/PacketDotNet/ArpPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2011 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/ArpPacket.cs
+++ b/PacketDotNet/ArpPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2011 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/DhcpV4/AddressRequestOption.cs
+++ b/PacketDotNet/DhcpV4/AddressRequestOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System.Net;
 using System.Net.Sockets;

--- a/PacketDotNet/DhcpV4/AddressRequestOption.cs
+++ b/PacketDotNet/DhcpV4/AddressRequestOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/AddressTimeOption.cs
+++ b/PacketDotNet/DhcpV4/AddressTimeOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using PacketDotNet.Utils.Converters;

--- a/PacketDotNet/DhcpV4/AddressTimeOption.cs
+++ b/PacketDotNet/DhcpV4/AddressTimeOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/BroadcastAddressOption.cs
+++ b/PacketDotNet/DhcpV4/BroadcastAddressOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System.Net;
 using System.Net.Sockets;

--- a/PacketDotNet/DhcpV4/BroadcastAddressOption.cs
+++ b/PacketDotNet/DhcpV4/BroadcastAddressOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/ClassIdOption.cs
+++ b/PacketDotNet/DhcpV4/ClassIdOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System.Text;
 

--- a/PacketDotNet/DhcpV4/ClassIdOption.cs
+++ b/PacketDotNet/DhcpV4/ClassIdOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/ClientIdOption.cs
+++ b/PacketDotNet/DhcpV4/ClientIdOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Linq;

--- a/PacketDotNet/DhcpV4/ClientIdOption.cs
+++ b/PacketDotNet/DhcpV4/ClientIdOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/DhcpV4Option.cs
+++ b/PacketDotNet/DhcpV4/DhcpV4Option.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo

--- a/PacketDotNet/DhcpV4/DhcpV4Option.cs
+++ b/PacketDotNet/DhcpV4/DhcpV4Option.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/DomainNameOption.cs
+++ b/PacketDotNet/DhcpV4/DomainNameOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Text;

--- a/PacketDotNet/DhcpV4/DomainNameOption.cs
+++ b/PacketDotNet/DhcpV4/DomainNameOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/DomainNameServerOption.cs
+++ b/PacketDotNet/DhcpV4/DomainNameServerOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/DhcpV4/DomainNameServerOption.cs
+++ b/PacketDotNet/DhcpV4/DomainNameServerOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/HostNameOption.cs
+++ b/PacketDotNet/DhcpV4/HostNameOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System.Text;
 

--- a/PacketDotNet/DhcpV4/HostNameOption.cs
+++ b/PacketDotNet/DhcpV4/HostNameOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/MaxMessageSizeOption.cs
+++ b/PacketDotNet/DhcpV4/MaxMessageSizeOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using PacketDotNet.Utils.Converters;
 

--- a/PacketDotNet/DhcpV4/MaxMessageSizeOption.cs
+++ b/PacketDotNet/DhcpV4/MaxMessageSizeOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/MessageOption.cs
+++ b/PacketDotNet/DhcpV4/MessageOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Text;

--- a/PacketDotNet/DhcpV4/MessageOption.cs
+++ b/PacketDotNet/DhcpV4/MessageOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/MessageTypeOption.cs
+++ b/PacketDotNet/DhcpV4/MessageTypeOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo

--- a/PacketDotNet/DhcpV4/MessageTypeOption.cs
+++ b/PacketDotNet/DhcpV4/MessageTypeOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/MtuInterfaceOption.cs
+++ b/PacketDotNet/DhcpV4/MtuInterfaceOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using PacketDotNet.Utils.Converters;
 

--- a/PacketDotNet/DhcpV4/MtuInterfaceOption.cs
+++ b/PacketDotNet/DhcpV4/MtuInterfaceOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/NTPServersOption.cs
+++ b/PacketDotNet/DhcpV4/NTPServersOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/DhcpV4/NTPServersOption.cs
+++ b/PacketDotNet/DhcpV4/NTPServersOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/PadOption.cs
+++ b/PacketDotNet/DhcpV4/PadOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo

--- a/PacketDotNet/DhcpV4/PadOption.cs
+++ b/PacketDotNet/DhcpV4/PadOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/ParameterListOption.cs
+++ b/PacketDotNet/DhcpV4/ParameterListOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/DhcpV4/ParameterListOption.cs
+++ b/PacketDotNet/DhcpV4/ParameterListOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/RebindingTimeOption.cs
+++ b/PacketDotNet/DhcpV4/RebindingTimeOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using PacketDotNet.Utils.Converters;

--- a/PacketDotNet/DhcpV4/RebindingTimeOption.cs
+++ b/PacketDotNet/DhcpV4/RebindingTimeOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/RenewalTimeOption.cs
+++ b/PacketDotNet/DhcpV4/RenewalTimeOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using PacketDotNet.Utils.Converters;

--- a/PacketDotNet/DhcpV4/RenewalTimeOption.cs
+++ b/PacketDotNet/DhcpV4/RenewalTimeOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/RouterOption.cs
+++ b/PacketDotNet/DhcpV4/RouterOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/DhcpV4/RouterOption.cs
+++ b/PacketDotNet/DhcpV4/RouterOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/ServerIdOption.cs
+++ b/PacketDotNet/DhcpV4/ServerIdOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System.Net;
 using System.Net.Sockets;

--- a/PacketDotNet/DhcpV4/ServerIdOption.cs
+++ b/PacketDotNet/DhcpV4/ServerIdOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/SubnetMaskOption.cs
+++ b/PacketDotNet/DhcpV4/SubnetMaskOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System.Net;
 using System.Net.Sockets;

--- a/PacketDotNet/DhcpV4/SubnetMaskOption.cs
+++ b/PacketDotNet/DhcpV4/SubnetMaskOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/TFTPServerNameOption.cs
+++ b/PacketDotNet/DhcpV4/TFTPServerNameOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Text;

--- a/PacketDotNet/DhcpV4/TFTPServerNameOption.cs
+++ b/PacketDotNet/DhcpV4/TFTPServerNameOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/TimeOffsetOption.cs
+++ b/PacketDotNet/DhcpV4/TimeOffsetOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using PacketDotNet.Utils.Converters;

--- a/PacketDotNet/DhcpV4/TimeOffsetOption.cs
+++ b/PacketDotNet/DhcpV4/TimeOffsetOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/TimeServerOption.cs
+++ b/PacketDotNet/DhcpV4/TimeServerOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/DhcpV4/TimeServerOption.cs
+++ b/PacketDotNet/DhcpV4/TimeServerOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/UnsupportedOption.cs
+++ b/PacketDotNet/DhcpV4/UnsupportedOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4/UnsupportedOption.cs
+++ b/PacketDotNet/DhcpV4/UnsupportedOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 

--- a/PacketDotNet/DhcpV4/VendorSpecificOption.cs
+++ b/PacketDotNet/DhcpV4/VendorSpecificOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Linq;

--- a/PacketDotNet/DhcpV4/VendorSpecificOption.cs
+++ b/PacketDotNet/DhcpV4/VendorSpecificOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4Fields.cs
+++ b/PacketDotNet/DhcpV4Fields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/DhcpV4Fields.cs
+++ b/PacketDotNet/DhcpV4Fields.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4HardwareType.cs
+++ b/PacketDotNet/DhcpV4HardwareType.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo

--- a/PacketDotNet/DhcpV4HardwareType.cs
+++ b/PacketDotNet/DhcpV4HardwareType.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4MessageType.cs
+++ b/PacketDotNet/DhcpV4MessageType.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo

--- a/PacketDotNet/DhcpV4MessageType.cs
+++ b/PacketDotNet/DhcpV4MessageType.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4Operation.cs
+++ b/PacketDotNet/DhcpV4Operation.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo

--- a/PacketDotNet/DhcpV4Operation.cs
+++ b/PacketDotNet/DhcpV4Operation.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4OptionType.cs
+++ b/PacketDotNet/DhcpV4OptionType.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable IdentifierTypo

--- a/PacketDotNet/DhcpV4OptionType.cs
+++ b/PacketDotNet/DhcpV4OptionType.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DhcpV4Packet.cs
+++ b/PacketDotNet/DhcpV4Packet.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/DhcpV4Packet.cs
+++ b/PacketDotNet/DhcpV4Packet.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/PacketDotNet/DrdaCodepointType.cs
+++ b/PacketDotNet/DrdaCodepointType.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Andrew <pandipd@outlook.com>

--- a/PacketDotNet/DrdaCodepointType.cs
+++ b/PacketDotNet/DrdaCodepointType.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Andrew <pandipd@outlook.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/DrdaDdmFields.cs
+++ b/PacketDotNet/DrdaDdmFields.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Andrew <pandipd@outlook.com>

--- a/PacketDotNet/DrdaDdmFields.cs
+++ b/PacketDotNet/DrdaDdmFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Andrew <pandipd@outlook.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/DrdaDdmPacket.cs
+++ b/PacketDotNet/DrdaDdmPacket.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Andrew <pandipd@outlook.com>

--- a/PacketDotNet/DrdaDdmPacket.cs
+++ b/PacketDotNet/DrdaDdmPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Andrew <pandipd@outlook.com>
- */
 
 using System.Collections.Generic;
 using System.Text;

--- a/PacketDotNet/DrdaDdmParameter.cs
+++ b/PacketDotNet/DrdaDdmParameter.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Andrew <pandipd@outlook.com>

--- a/PacketDotNet/DrdaDdmParameter.cs
+++ b/PacketDotNet/DrdaDdmParameter.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Andrew <pandipd@outlook.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/DrdaPacket.cs
+++ b/PacketDotNet/DrdaPacket.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Andrew <pandipd@outlook.com>

--- a/PacketDotNet/DrdaPacket.cs
+++ b/PacketDotNet/DrdaPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Andrew <pandipd@outlook.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/EthernetFields.cs
+++ b/PacketDotNet/EthernetFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/EthernetFields.cs
+++ b/PacketDotNet/EthernetFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/EthernetPacket.cs
+++ b/PacketDotNet/EthernetPacket.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/EthernetPacket.cs
+++ b/PacketDotNet/EthernetPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/EthernetType.cs
+++ b/PacketDotNet/EthernetType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 using System.Diagnostics.CodeAnalysis;

--- a/PacketDotNet/EthernetType.cs
+++ b/PacketDotNet/EthernetType.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/GreFields.cs
+++ b/PacketDotNet/GreFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2018 Steven Haufe<haufes@hotmail.com>

--- a/PacketDotNet/GreFields.cs
+++ b/PacketDotNet/GreFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2018 Steven Haufe<haufes@hotmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/GrePacket.cs
+++ b/PacketDotNet/GrePacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2018 Steven Haufe<haufes@hotmail.com>

--- a/PacketDotNet/GrePacket.cs
+++ b/PacketDotNet/GrePacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/IPPacket.cs
+++ b/PacketDotNet/IPPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IPPacket.cs
+++ b/PacketDotNet/IPPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/IPVersion.cs
+++ b/PacketDotNet/IPVersion.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IPVersion.cs
+++ b/PacketDotNet/IPVersion.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System.Diagnostics.CodeAnalysis;
 

--- a/PacketDotNet/IPv4Fields.cs
+++ b/PacketDotNet/IPv4Fields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IPv4Fields.cs
+++ b/PacketDotNet/IPv4Fields.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/IPv4Packet.cs
+++ b/PacketDotNet/IPv4Packet.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IPv4Packet.cs
+++ b/PacketDotNet/IPv4Packet.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/IPv6ExtensionHeader.cs
+++ b/PacketDotNet/IPv6ExtensionHeader.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2018 Steven Haufe <haufes@hotmail.com>

--- a/PacketDotNet/IPv6ExtensionHeader.cs
+++ b/PacketDotNet/IPv6ExtensionHeader.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/IPv6Fields.cs
+++ b/PacketDotNet/IPv6Fields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IPv6Fields.cs
+++ b/PacketDotNet/IPv6Fields.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/IPv6Packet.cs
+++ b/PacketDotNet/IPv6Packet.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2009 David Bond <mokon@mokon.net>

--- a/PacketDotNet/IPv6Packet.cs
+++ b/PacketDotNet/IPv6Packet.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/IcmpV4Fields.cs
+++ b/PacketDotNet/IcmpV4Fields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/IcmpV4Fields.cs
+++ b/PacketDotNet/IcmpV4Fields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IcmpV4Packet.cs
+++ b/PacketDotNet/IcmpV4Packet.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/IcmpV4Packet.cs
+++ b/PacketDotNet/IcmpV4Packet.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IcmpV4TypeCode.cs
+++ b/PacketDotNet/IcmpV4TypeCode.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IcmpV4TypeCode.cs
+++ b/PacketDotNet/IcmpV4TypeCode.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System.Diagnostics.CodeAnalysis;
 

--- a/PacketDotNet/IcmpV6Fields.cs
+++ b/PacketDotNet/IcmpV6Fields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/IcmpV6Fields.cs
+++ b/PacketDotNet/IcmpV6Fields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IcmpV6Packet.cs
+++ b/PacketDotNet/IcmpV6Packet.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IcmpV6Packet.cs
+++ b/PacketDotNet/IcmpV6Packet.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/IcmpV6Type.cs
+++ b/PacketDotNet/IcmpV6Type.cs
@@ -1,5 +1,5 @@
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/IcmpV6Type.cs
+++ b/PacketDotNet/IcmpV6Type.cs
@@ -1,18 +1,9 @@
 /*
-This file is part of PacketDotNet.
+This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/AcknowledgmentFrame.cs
+++ b/PacketDotNet/Ieee80211/AcknowledgmentFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/AcknowledgmentFrame.cs
+++ b/PacketDotNet/Ieee80211/AcknowledgmentFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/ActionFrame.cs
+++ b/PacketDotNet/Ieee80211/ActionFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/ActionFrame.cs
+++ b/PacketDotNet/Ieee80211/ActionFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/AssociationRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/AssociationRequestFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/AssociationRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/AssociationRequestFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/AssociationResponseFrame.cs
+++ b/PacketDotNet/Ieee80211/AssociationResponseFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/AssociationResponseFrame.cs
+++ b/PacketDotNet/Ieee80211/AssociationResponseFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/AuthenticationFrame.cs
+++ b/PacketDotNet/Ieee80211/AuthenticationFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/AuthenticationFrame.cs
+++ b/PacketDotNet/Ieee80211/AuthenticationFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/AuthenticationStatusCode.cs
+++ b/PacketDotNet/Ieee80211/AuthenticationStatusCode.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/AuthenticationStatusCode.cs
+++ b/PacketDotNet/Ieee80211/AuthenticationStatusCode.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/BeaconFrame.cs
+++ b/PacketDotNet/Ieee80211/BeaconFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/BeaconFrame.cs
+++ b/PacketDotNet/Ieee80211/BeaconFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/BlockAcknowledgmentControlField.cs
+++ b/PacketDotNet/Ieee80211/BlockAcknowledgmentControlField.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/BlockAcknowledgmentControlField.cs
+++ b/PacketDotNet/Ieee80211/BlockAcknowledgmentControlField.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/BlockAcknowledgmentFrame.cs
+++ b/PacketDotNet/Ieee80211/BlockAcknowledgmentFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/BlockAcknowledgmentFrame.cs
+++ b/PacketDotNet/Ieee80211/BlockAcknowledgmentFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/BlockAcknowledgmentRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/BlockAcknowledgmentRequestFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/BlockAcknowledgmentRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/BlockAcknowledgmentRequestFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/CapabilityInformationField.cs
+++ b/PacketDotNet/Ieee80211/CapabilityInformationField.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/CapabilityInformationField.cs
+++ b/PacketDotNet/Ieee80211/CapabilityInformationField.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/ContentionFreeEndFrame.cs
+++ b/PacketDotNet/Ieee80211/ContentionFreeEndFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/ContentionFreeEndFrame.cs
+++ b/PacketDotNet/Ieee80211/ContentionFreeEndFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/CtsFrame.cs
+++ b/PacketDotNet/Ieee80211/CtsFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/CtsFrame.cs
+++ b/PacketDotNet/Ieee80211/CtsFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/DataDataFrame.cs
+++ b/PacketDotNet/Ieee80211/DataDataFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/DataDataFrame.cs
+++ b/PacketDotNet/Ieee80211/DataDataFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/DataFrame.cs
+++ b/PacketDotNet/Ieee80211/DataFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/DataFrame.cs
+++ b/PacketDotNet/Ieee80211/DataFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/DeauthenticationFrame.cs
+++ b/PacketDotNet/Ieee80211/DeauthenticationFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/DeauthenticationFrame.cs
+++ b/PacketDotNet/Ieee80211/DeauthenticationFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/DisassociationFrame.cs
+++ b/PacketDotNet/Ieee80211/DisassociationFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/DisassociationFrame.cs
+++ b/PacketDotNet/Ieee80211/DisassociationFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/DurationField.cs
+++ b/PacketDotNet/Ieee80211/DurationField.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/DurationField.cs
+++ b/PacketDotNet/Ieee80211/DurationField.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/FrameControlField.FrameSubTypes.cs
+++ b/PacketDotNet/Ieee80211/FrameControlField.FrameSubTypes.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/FrameControlField.FrameSubTypes.cs
+++ b/PacketDotNet/Ieee80211/FrameControlField.FrameSubTypes.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System.Diagnostics.CodeAnalysis;
 

--- a/PacketDotNet/Ieee80211/FrameControlField.FrameTypes.cs
+++ b/PacketDotNet/Ieee80211/FrameControlField.FrameTypes.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/FrameControlField.FrameTypes.cs
+++ b/PacketDotNet/Ieee80211/FrameControlField.FrameTypes.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet.Ieee80211
 {

--- a/PacketDotNet/Ieee80211/FrameControlField.cs
+++ b/PacketDotNet/Ieee80211/FrameControlField.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/Ieee80211/FrameControlField.cs
+++ b/PacketDotNet/Ieee80211/FrameControlField.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/InformationElement.ElementId.cs
+++ b/PacketDotNet/Ieee80211/InformationElement.ElementId.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2012 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet.Ieee80211
 {

--- a/PacketDotNet/Ieee80211/InformationElement.ElementId.cs
+++ b/PacketDotNet/Ieee80211/InformationElement.ElementId.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2012 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/InformationElement.cs
+++ b/PacketDotNet/Ieee80211/InformationElement.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2012 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Linq;

--- a/PacketDotNet/Ieee80211/InformationElement.cs
+++ b/PacketDotNet/Ieee80211/InformationElement.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2012 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/InformationElementList.cs
+++ b/PacketDotNet/Ieee80211/InformationElementList.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/InformationElementList.cs
+++ b/PacketDotNet/Ieee80211/InformationElementList.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/LogicalLinkControl.cs
+++ b/PacketDotNet/Ieee80211/LogicalLinkControl.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Threading;

--- a/PacketDotNet/Ieee80211/LogicalLinkControl.cs
+++ b/PacketDotNet/Ieee80211/LogicalLinkControl.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/LogicalLinkControlFields.cs
+++ b/PacketDotNet/Ieee80211/LogicalLinkControlFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/LogicalLinkControlFields.cs
+++ b/PacketDotNet/Ieee80211/LogicalLinkControlFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet.Ieee80211
 {

--- a/PacketDotNet/Ieee80211/MacFields.cs
+++ b/PacketDotNet/Ieee80211/MacFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/MacFields.cs
+++ b/PacketDotNet/Ieee80211/MacFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet.Ieee80211
 {

--- a/PacketDotNet/Ieee80211/MacFrame.cs
+++ b/PacketDotNet/Ieee80211/MacFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/MacFrame.cs
+++ b/PacketDotNet/Ieee80211/MacFrame.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/PacketDotNet/Ieee80211/ManagementFrame.cs
+++ b/PacketDotNet/Ieee80211/ManagementFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/ManagementFrame.cs
+++ b/PacketDotNet/Ieee80211/ManagementFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/NullDataFrame.cs
+++ b/PacketDotNet/Ieee80211/NullDataFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/NullDataFrame.cs
+++ b/PacketDotNet/Ieee80211/NullDataFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/PpiFieldType.cs
+++ b/PacketDotNet/Ieee80211/PpiFieldType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2011 David Thedens <dthedens@metageek.net>

--- a/PacketDotNet/Ieee80211/PpiFieldType.cs
+++ b/PacketDotNet/Ieee80211/PpiFieldType.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/PpiFields.cs
+++ b/PacketDotNet/Ieee80211/PpiFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2011 David Thedens <dthedens@metageek.net>

--- a/PacketDotNet/Ieee80211/PpiFields.cs
+++ b/PacketDotNet/Ieee80211/PpiFields.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/PpiHeaderFields.cs
+++ b/PacketDotNet/Ieee80211/PpiHeaderFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/PpiHeaderFields.cs
+++ b/PacketDotNet/Ieee80211/PpiHeaderFields.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/PpiPacket.cs
+++ b/PacketDotNet/Ieee80211/PpiPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2011 David Thedens

--- a/PacketDotNet/Ieee80211/PpiPacket.cs
+++ b/PacketDotNet/Ieee80211/PpiPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/ProbeRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/ProbeRequestFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/ProbeRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/ProbeRequestFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/ProbeResponseFrame.cs
+++ b/PacketDotNet/Ieee80211/ProbeResponseFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/ProbeResponseFrame.cs
+++ b/PacketDotNet/Ieee80211/ProbeResponseFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/QosDataFrame.cs
+++ b/PacketDotNet/Ieee80211/QosDataFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/QosDataFrame.cs
+++ b/PacketDotNet/Ieee80211/QosDataFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/QosNullDataFrame.cs
+++ b/PacketDotNet/Ieee80211/QosNullDataFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/QosNullDataFrame.cs
+++ b/PacketDotNet/Ieee80211/QosNullDataFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/RadioFields.cs
+++ b/PacketDotNet/Ieee80211/RadioFields.cs
@@ -1,5 +1,5 @@
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/RadioFields.cs
+++ b/PacketDotNet/Ieee80211/RadioFields.cs
@@ -1,18 +1,9 @@
 /*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/RadioPacket.cs
+++ b/PacketDotNet/Ieee80211/RadioPacket.cs
@@ -1,5 +1,5 @@
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/RadioPacket.cs
+++ b/PacketDotNet/Ieee80211/RadioPacket.cs
@@ -1,18 +1,9 @@
 /*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/RadioTapChannelFlags.cs
+++ b/PacketDotNet/Ieee80211/RadioTapChannelFlags.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/RadioTapChannelFlags.cs
+++ b/PacketDotNet/Ieee80211/RadioTapChannelFlags.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/RadioTapFields.cs
+++ b/PacketDotNet/Ieee80211/RadioTapFields.cs
@@ -1,5 +1,5 @@
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/RadioTapFields.cs
+++ b/PacketDotNet/Ieee80211/RadioTapFields.cs
@@ -1,18 +1,9 @@
 /*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/RadioTapFlags.cs
+++ b/PacketDotNet/Ieee80211/RadioTapFlags.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/RadioTapFlags.cs
+++ b/PacketDotNet/Ieee80211/RadioTapFlags.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/RadioTapType.cs
+++ b/PacketDotNet/Ieee80211/RadioTapType.cs
@@ -1,5 +1,5 @@
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/RadioTapType.cs
+++ b/PacketDotNet/Ieee80211/RadioTapType.cs
@@ -1,18 +1,9 @@
 /*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee80211/ReasonCodes.cs
+++ b/PacketDotNet/Ieee80211/ReasonCodes.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/ReasonCodes.cs
+++ b/PacketDotNet/Ieee80211/ReasonCodes.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/ReassociationRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/ReassociationRequestFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/ReassociationRequestFrame.cs
+++ b/PacketDotNet/Ieee80211/ReassociationRequestFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/RtsFrame.cs
+++ b/PacketDotNet/Ieee80211/RtsFrame.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/RtsFrame.cs
+++ b/PacketDotNet/Ieee80211/RtsFrame.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee80211/SequenceControlField.cs
+++ b/PacketDotNet/Ieee80211/SequenceControlField.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/PacketDotNet/Ieee80211/SequenceControlField.cs
+++ b/PacketDotNet/Ieee80211/SequenceControlField.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Ieee8021QFields.cs
+++ b/PacketDotNet/Ieee8021QFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2013 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/Ieee8021QFields.cs
+++ b/PacketDotNet/Ieee8021QFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2013 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Ieee8021QPacket.cs
+++ b/PacketDotNet/Ieee8021QPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2013 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/Ieee8021QPacket.cs
+++ b/PacketDotNet/Ieee8021QPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2013 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IeeeP8021PPriority.cs
+++ b/PacketDotNet/IeeeP8021PPriority.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2013 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System.Diagnostics.CodeAnalysis;
 

--- a/PacketDotNet/IeeeP8021PPriority.cs
+++ b/PacketDotNet/IeeeP8021PPriority.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2013 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IgmpV2Fields.cs
+++ b/PacketDotNet/IgmpV2Fields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/IgmpV2Fields.cs
+++ b/PacketDotNet/IgmpV2Fields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IgmpV2MessageType.cs
+++ b/PacketDotNet/IgmpV2MessageType.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/IgmpV2MessageType.cs
+++ b/PacketDotNet/IgmpV2MessageType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IgmpV2Packet.cs
+++ b/PacketDotNet/IgmpV2Packet.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/IgmpV2Packet.cs
+++ b/PacketDotNet/IgmpV2Packet.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/InternetLinkLayerPacket.cs
+++ b/PacketDotNet/InternetLinkLayerPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/InternetLinkLayerPacket.cs
+++ b/PacketDotNet/InternetLinkLayerPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/InternetPacket.cs
+++ b/PacketDotNet/InternetPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/InternetPacket.cs
+++ b/PacketDotNet/InternetPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/L2tpFields.cs
+++ b/PacketDotNet/L2tpFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2018 Steven Haufe<haufes@hotmail.com>

--- a/PacketDotNet/L2tpFields.cs
+++ b/PacketDotNet/L2tpFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2018 Steven Haufe<haufes@hotmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/L2tpPacket.cs
+++ b/PacketDotNet/L2tpPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2018 Steven Haufe<haufes@hotmail.com>

--- a/PacketDotNet/L2tpPacket.cs
+++ b/PacketDotNet/L2tpPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/LazySlim.cs
+++ b/PacketDotNet/LazySlim.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 using System;

--- a/PacketDotNet/LazySlim.cs
+++ b/PacketDotNet/LazySlim.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/LinkLayers.cs
+++ b/PacketDotNet/LinkLayers.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/LinkLayers.cs
+++ b/PacketDotNet/LinkLayers.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/LinuxSllFields.cs
+++ b/PacketDotNet/LinuxSllFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/LinuxSllFields.cs
+++ b/PacketDotNet/LinuxSllFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/LinuxSllPacket.cs
+++ b/PacketDotNet/LinuxSllPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/LinuxSllPacket.cs
+++ b/PacketDotNet/LinuxSllPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/LinuxSllType.cs
+++ b/PacketDotNet/LinuxSllType.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/LinuxSllType.cs
+++ b/PacketDotNet/LinuxSllType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Lldp/CapabilityOptions.cs
+++ b/PacketDotNet/Lldp/CapabilityOptions.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/CapabilityOptions.cs
+++ b/PacketDotNet/Lldp/CapabilityOptions.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/ChassisIdTlv.cs
+++ b/PacketDotNet/Lldp/ChassisIdTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/ChassisIdTlv.cs
+++ b/PacketDotNet/Lldp/ChassisIdTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/ChassisSubType.cs
+++ b/PacketDotNet/Lldp/ChassisSubType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/ChassisSubType.cs
+++ b/PacketDotNet/Lldp/ChassisSubType.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/EndOfLldpduTlv.cs
+++ b/PacketDotNet/Lldp/EndOfLldpduTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/EndOfLldpduTlv.cs
+++ b/PacketDotNet/Lldp/EndOfLldpduTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/IanaAddressFamily.cs
+++ b/PacketDotNet/Lldp/IanaAddressFamily.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/IanaAddressFamily.cs
+++ b/PacketDotNet/Lldp/IanaAddressFamily.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/InterfaceNumber.cs
+++ b/PacketDotNet/Lldp/InterfaceNumber.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/InterfaceNumber.cs
+++ b/PacketDotNet/Lldp/InterfaceNumber.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/ManagementAddressTlv.cs
+++ b/PacketDotNet/Lldp/ManagementAddressTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/ManagementAddressTlv.cs
+++ b/PacketDotNet/Lldp/ManagementAddressTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/NetworkAddress.cs
+++ b/PacketDotNet/Lldp/NetworkAddress.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/NetworkAddress.cs
+++ b/PacketDotNet/Lldp/NetworkAddress.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/OrganizationSpecificTlv.cs
+++ b/PacketDotNet/Lldp/OrganizationSpecificTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/OrganizationSpecificTlv.cs
+++ b/PacketDotNet/Lldp/OrganizationSpecificTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/PortDescriptionTlv.cs
+++ b/PacketDotNet/Lldp/PortDescriptionTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/PortDescriptionTlv.cs
+++ b/PacketDotNet/Lldp/PortDescriptionTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/PortIdTlv.cs
+++ b/PacketDotNet/Lldp/PortIdTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/PortIdTlv.cs
+++ b/PacketDotNet/Lldp/PortIdTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/PortSubType.cs
+++ b/PacketDotNet/Lldp/PortSubType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/PortSubType.cs
+++ b/PacketDotNet/Lldp/PortSubType.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/StringTlv.cs
+++ b/PacketDotNet/Lldp/StringTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/StringTlv.cs
+++ b/PacketDotNet/Lldp/StringTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/SystemCapabilitiesTlv.cs
+++ b/PacketDotNet/Lldp/SystemCapabilitiesTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/SystemCapabilitiesTlv.cs
+++ b/PacketDotNet/Lldp/SystemCapabilitiesTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/SystemDescriptionTlv.cs
+++ b/PacketDotNet/Lldp/SystemDescriptionTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/SystemDescriptionTlv.cs
+++ b/PacketDotNet/Lldp/SystemDescriptionTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/SystemNameTlv.cs
+++ b/PacketDotNet/Lldp/SystemNameTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/SystemNameTlv.cs
+++ b/PacketDotNet/Lldp/SystemNameTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/TimeToLiveTlv.cs
+++ b/PacketDotNet/Lldp/TimeToLiveTlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/TimeToLiveTlv.cs
+++ b/PacketDotNet/Lldp/TimeToLiveTlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/Tlv.cs
+++ b/PacketDotNet/Lldp/Tlv.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/Tlv.cs
+++ b/PacketDotNet/Lldp/Tlv.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/TlvCollection.cs
+++ b/PacketDotNet/Lldp/TlvCollection.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/TlvCollection.cs
+++ b/PacketDotNet/Lldp/TlvCollection.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/TlvType.cs
+++ b/PacketDotNet/Lldp/TlvType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/TlvType.cs
+++ b/PacketDotNet/Lldp/TlvType.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lldp/TlvTypeLength.cs
+++ b/PacketDotNet/Lldp/TlvTypeLength.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Lldp/TlvTypeLength.cs
+++ b/PacketDotNet/Lldp/TlvTypeLength.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/LldpPacket.cs
+++ b/PacketDotNet/LldpPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/LldpPacket.cs
+++ b/PacketDotNet/LldpPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Lsa/LinkStateAdvertisement.cs
+++ b/PacketDotNet/Lsa/LinkStateAdvertisement.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>

--- a/PacketDotNet/Lsa/LinkStateAdvertisement.cs
+++ b/PacketDotNet/Lsa/LinkStateAdvertisement.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>
- */
 
 using System;
 using System.Net;

--- a/PacketDotNet/Lsa/LinkStateAdvertisementType.cs
+++ b/PacketDotNet/Lsa/LinkStateAdvertisementType.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>
- */
 
 namespace PacketDotNet.Lsa
 {

--- a/PacketDotNet/Lsa/LinkStateAdvertisementType.cs
+++ b/PacketDotNet/Lsa/LinkStateAdvertisementType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>

--- a/PacketDotNet/Lsa/LinkStateFields.cs
+++ b/PacketDotNet/Lsa/LinkStateFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>
- */
 
 namespace PacketDotNet.Lsa
 {

--- a/PacketDotNet/Lsa/LinkStateFields.cs
+++ b/PacketDotNet/Lsa/LinkStateFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>

--- a/PacketDotNet/NullFields.cs
+++ b/PacketDotNet/NullFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/NullFields.cs
+++ b/PacketDotNet/NullFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/NullPacket.cs
+++ b/PacketDotNet/NullPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Text;

--- a/PacketDotNet/NullPacket.cs
+++ b/PacketDotNet/NullPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/NullPacketType.cs
+++ b/PacketDotNet/NullPacketType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
 *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/NullPacketType.cs
+++ b/PacketDotNet/NullPacketType.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/OspfPacket.cs
+++ b/PacketDotNet/OspfPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>
- */
 
 using System;
 

--- a/PacketDotNet/OspfPacket.cs
+++ b/PacketDotNet/OspfPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>

--- a/PacketDotNet/OspfPacketType.cs
+++ b/PacketDotNet/OspfPacketType.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/OspfPacketType.cs
+++ b/PacketDotNet/OspfPacketType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>

--- a/PacketDotNet/OspfV2Fields.cs
+++ b/PacketDotNet/OspfV2Fields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/OspfV2Fields.cs
+++ b/PacketDotNet/OspfV2Fields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>

--- a/PacketDotNet/OspfV2Packet.cs
+++ b/PacketDotNet/OspfV2Packet.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>

--- a/PacketDotNet/OspfV2Packet.cs
+++ b/PacketDotNet/OspfV2Packet.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>
- */
 
 using System;
 using System.Net;

--- a/PacketDotNet/OspfVersion.cs
+++ b/PacketDotNet/OspfVersion.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/OspfVersion.cs
+++ b/PacketDotNet/OspfVersion.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2011 Georgi Baychev <georgi.baychev@gmail.com>

--- a/PacketDotNet/Packet.cs
+++ b/PacketDotNet/Packet.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/PacketDotNet/Packet.cs
+++ b/PacketDotNet/Packet.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/PacketOrByteArraySegment.cs
+++ b/PacketDotNet/PacketOrByteArraySegment.cs
@@ -1,5 +1,5 @@
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/PacketOrByteArraySegment.cs
+++ b/PacketDotNet/PacketOrByteArraySegment.cs
@@ -1,18 +1,9 @@
 /*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/PayloadType.cs
+++ b/PacketDotNet/PayloadType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/PayloadType.cs
+++ b/PacketDotNet/PayloadType.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/PppFields.cs
+++ b/PacketDotNet/PppFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/PppFields.cs
+++ b/PacketDotNet/PppFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/PppPacket.cs
+++ b/PacketDotNet/PppPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/PppPacket.cs
+++ b/PacketDotNet/PppPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/PppProtocol.cs
+++ b/PacketDotNet/PppProtocol.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System.Diagnostics.CodeAnalysis;
 

--- a/PacketDotNet/PppProtocol.cs
+++ b/PacketDotNet/PppProtocol.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/PppoeCode.cs
+++ b/PacketDotNet/PppoeCode.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/PppoeCode.cs
+++ b/PacketDotNet/PppoeCode.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/PppoeFields.cs
+++ b/PacketDotNet/PppoeFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/PppoeFields.cs
+++ b/PacketDotNet/PppoeFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/PppoePacket.cs
+++ b/PacketDotNet/PppoePacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/PppoePacket.cs
+++ b/PacketDotNet/PppoePacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/RawIPPacket.cs
+++ b/PacketDotNet/RawIPPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/RawIPPacket.cs
+++ b/PacketDotNet/RawIPPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/RawIPPacketProtocol.cs
+++ b/PacketDotNet/RawIPPacketProtocol.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/RawIPPacketProtocol.cs
+++ b/PacketDotNet/RawIPPacketProtocol.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/StringOutputType.cs
+++ b/PacketDotNet/StringOutputType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 namespace PacketDotNet

--- a/PacketDotNet/StringOutputType.cs
+++ b/PacketDotNet/StringOutputType.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Tcp/AlternateChecksumDataOption.cs
+++ b/PacketDotNet/Tcp/AlternateChecksumDataOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/AlternateChecksumDataOption.cs
+++ b/PacketDotNet/Tcp/AlternateChecksumDataOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using System;
 

--- a/PacketDotNet/Tcp/AlternateChecksumRequestOption.cs
+++ b/PacketDotNet/Tcp/AlternateChecksumRequestOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 namespace PacketDotNet.Tcp
 {

--- a/PacketDotNet/Tcp/AlternateChecksumRequestOption.cs
+++ b/PacketDotNet/Tcp/AlternateChecksumRequestOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/ChecksumAlgorithmType.cs
+++ b/PacketDotNet/Tcp/ChecksumAlgorithmType.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 namespace PacketDotNet.Tcp
 {

--- a/PacketDotNet/Tcp/ChecksumAlgorithmType.cs
+++ b/PacketDotNet/Tcp/ChecksumAlgorithmType.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/EchoOption.cs
+++ b/PacketDotNet/Tcp/EchoOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/EchoOption.cs
+++ b/PacketDotNet/Tcp/EchoOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using System;
 

--- a/PacketDotNet/Tcp/EchoReplyOption.cs
+++ b/PacketDotNet/Tcp/EchoReplyOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/EchoReplyOption.cs
+++ b/PacketDotNet/Tcp/EchoReplyOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using System;
 

--- a/PacketDotNet/Tcp/EndOfOptionsOption.cs
+++ b/PacketDotNet/Tcp/EndOfOptionsOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 namespace PacketDotNet.Tcp
 {

--- a/PacketDotNet/Tcp/EndOfOptionsOption.cs
+++ b/PacketDotNet/Tcp/EndOfOptionsOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/MD5SignatureOption.cs
+++ b/PacketDotNet/Tcp/MD5SignatureOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/MD5SignatureOption.cs
+++ b/PacketDotNet/Tcp/MD5SignatureOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using System;
 

--- a/PacketDotNet/Tcp/MaximumSegmentSizeOption.cs
+++ b/PacketDotNet/Tcp/MaximumSegmentSizeOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using PacketDotNet.Utils.Converters;
 

--- a/PacketDotNet/Tcp/MaximumSegmentSizeOption.cs
+++ b/PacketDotNet/Tcp/MaximumSegmentSizeOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/NoOperationOption.cs
+++ b/PacketDotNet/Tcp/NoOperationOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 namespace PacketDotNet.Tcp
 {

--- a/PacketDotNet/Tcp/NoOperationOption.cs
+++ b/PacketDotNet/Tcp/NoOperationOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/OptionTypes.cs
+++ b/PacketDotNet/Tcp/OptionTypes.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/Tcp/OptionTypes.cs
+++ b/PacketDotNet/Tcp/OptionTypes.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Tcp/SelectiveAcknowledgmentOption.cs
+++ b/PacketDotNet/Tcp/SelectiveAcknowledgmentOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using PacketDotNet.Utils.Converters;
 

--- a/PacketDotNet/Tcp/SelectiveAcknowledgmentOption.cs
+++ b/PacketDotNet/Tcp/SelectiveAcknowledgmentOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/SelectiveAcknowledgmentPermittedOption.cs
+++ b/PacketDotNet/Tcp/SelectiveAcknowledgmentPermittedOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 namespace PacketDotNet.Tcp
 {

--- a/PacketDotNet/Tcp/SelectiveAcknowledgmentPermittedOption.cs
+++ b/PacketDotNet/Tcp/SelectiveAcknowledgmentPermittedOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/TcpOption.cs
+++ b/PacketDotNet/Tcp/TcpOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using System;
 using PacketDotNet.Utils;

--- a/PacketDotNet/Tcp/TcpOption.cs
+++ b/PacketDotNet/Tcp/TcpOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/TimeStampOption.cs
+++ b/PacketDotNet/Tcp/TimeStampOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using PacketDotNet.Utils.Converters;
 

--- a/PacketDotNet/Tcp/TimeStampOption.cs
+++ b/PacketDotNet/Tcp/TimeStampOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/UnsupportedOption.cs
+++ b/PacketDotNet/Tcp/UnsupportedOption.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 namespace PacketDotNet.Tcp

--- a/PacketDotNet/Tcp/UnsupportedOption.cs
+++ b/PacketDotNet/Tcp/UnsupportedOption.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Tcp/UserTimeoutOption.cs
+++ b/PacketDotNet/Tcp/UserTimeoutOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using PacketDotNet.Utils.Converters;
 

--- a/PacketDotNet/Tcp/UserTimeoutOption.cs
+++ b/PacketDotNet/Tcp/UserTimeoutOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/Tcp/WindowScaleFactorOption.cs
+++ b/PacketDotNet/Tcp/WindowScaleFactorOption.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 namespace PacketDotNet.Tcp
 {

--- a/PacketDotNet/Tcp/WindowScaleFactorOption.cs
+++ b/PacketDotNet/Tcp/WindowScaleFactorOption.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/TcpFields.cs
+++ b/PacketDotNet/TcpFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/TcpFields.cs
+++ b/PacketDotNet/TcpFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/TcpPacket.cs
+++ b/PacketDotNet/TcpPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/TcpPacket.cs
+++ b/PacketDotNet/TcpPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/ThrowHelper.cs
+++ b/PacketDotNet/ThrowHelper.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 using System;

--- a/PacketDotNet/ThrowHelper.cs
+++ b/PacketDotNet/ThrowHelper.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/TransportPacket.cs
+++ b/PacketDotNet/TransportPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 using PacketDotNet.Utils;

--- a/PacketDotNet/TransportPacket.cs
+++ b/PacketDotNet/TransportPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/UdpFields.cs
+++ b/PacketDotNet/UdpFields.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/UdpFields.cs
+++ b/PacketDotNet/UdpFields.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/UdpPacket.cs
+++ b/PacketDotNet/UdpPacket.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>

--- a/PacketDotNet/UdpPacket.cs
+++ b/PacketDotNet/UdpPacket.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2009 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/PacketDotNet/Utils/ByteArraySegment.cs
+++ b/PacketDotNet/Utils/ByteArraySegment.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 using System;

--- a/PacketDotNet/Utils/ByteArraySegment.cs
+++ b/PacketDotNet/Utils/ByteArraySegment.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Utils/ChecksumUtils.cs
+++ b/PacketDotNet/Utils/ChecksumUtils.cs
@@ -1,5 +1,5 @@
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Utils/ChecksumUtils.cs
+++ b/PacketDotNet/Utils/ChecksumUtils.cs
@@ -1,18 +1,9 @@
 /*
-This file is part of PacketDotNet.
+This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2005 Tamir Gal <tamir@tamirgal.com>

--- a/PacketDotNet/Utils/Converters/StringConverter.cs
+++ b/PacketDotNet/Utils/Converters/StringConverter.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Andrew <pandipd@outlook.com>
- */
 
 using System;
 using System.Text;

--- a/PacketDotNet/Utils/Converters/StringConverter.cs
+++ b/PacketDotNet/Utils/Converters/StringConverter.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Andrew <pandipd@outlook.com>

--- a/PacketDotNet/Utils/HexPrinter.cs
+++ b/PacketDotNet/Utils/HexPrinter.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 using System.Net.NetworkInformation;

--- a/PacketDotNet/Utils/HexPrinter.cs
+++ b/PacketDotNet/Utils/HexPrinter.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Utils/LazySlimExtensions.cs
+++ b/PacketDotNet/Utils/LazySlimExtensions.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 using System;

--- a/PacketDotNet/Utils/LazySlimExtensions.cs
+++ b/PacketDotNet/Utils/LazySlimExtensions.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/Utils/RandomUtils.cs
+++ b/PacketDotNet/Utils/RandomUtils.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 using System;

--- a/PacketDotNet/Utils/RandomUtils.cs
+++ b/PacketDotNet/Utils/RandomUtils.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/PacketDotNet/WakeOnLanFields.cs
+++ b/PacketDotNet/WakeOnLanFields.cs
@@ -2,18 +2,9 @@
 /*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2019 George Rahul<georgerahul143@gmail.com>

--- a/PacketDotNet/WakeOnLanFields.cs
+++ b/PacketDotNet/WakeOnLanFields.cs
@@ -1,14 +1,11 @@
 ﻿
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2019 George Rahul<georgerahul143@gmail.com>
- */
 
 namespace PacketDotNet
 {

--- a/PacketDotNet/WakeOnLanPacket.cs
+++ b/PacketDotNet/WakeOnLanPacket.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/PacketDotNet/WakeOnLanPacket.cs
+++ b/PacketDotNet/WakeOnLanPacket.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/LoggingConfiguration.cs
+++ b/Test/LoggingConfiguration.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/LoggingConfiguration.cs
+++ b/Test/LoggingConfiguration.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System.Reflection;
 using log4net;

--- a/Test/Misc/ByteArraySegmentTest.cs
+++ b/Test/Misc/ByteArraySegmentTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/Misc/ByteArraySegmentTest.cs
+++ b/Test/Misc/ByteArraySegmentTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/Misc/ChecksumUtilsTest.cs
+++ b/Test/Misc/ChecksumUtilsTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/Misc/ChecksumUtilsTest.cs
+++ b/Test/Misc/ChecksumUtilsTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/Misc/ConstructingPacketsTest.cs
+++ b/Test/Misc/ConstructingPacketsTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/Misc/ConstructingPacketsTest.cs
+++ b/Test/Misc/ConstructingPacketsTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/Misc/PacketTest.cs
+++ b/Test/Misc/PacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using NUnit.Framework;
 using PacketDotNet;

--- a/Test/Misc/PacketTest.cs
+++ b/Test/Misc/PacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/Misc/StringOutputTest.cs
+++ b/Test/Misc/StringOutputTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/Test/Misc/StringOutputTest.cs
+++ b/Test/Misc/StringOutputTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/ArpPacketTest.cs
+++ b/Test/PacketType/ArpPacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/ArpPacketTest.cs
+++ b/Test/PacketType/ArpPacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/PacketType/DhcpV4PacketTest.cs
+++ b/Test/PacketType/DhcpV4PacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  This file is licensed under the Apache License, Version 2.0.
- */
 
 using System;
 using System.Collections.Generic;

--- a/Test/PacketType/DhcpV4PacketTest.cs
+++ b/Test/PacketType/DhcpV4PacketTest.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  This file is licensed under the Apache License, Version 2.0.

--- a/Test/PacketType/DrdaPacketTest.cs
+++ b/Test/PacketType/DrdaPacketTest.cs
@@ -1,18 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Andrew <pandipd@outlook.com>

--- a/Test/PacketType/DrdaPacketTest.cs
+++ b/Test/PacketType/DrdaPacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Andrew <pandipd@outlook.com>
- */
 
 using System.Collections.Generic;
 using NUnit.Framework;

--- a/Test/PacketType/EthernetPacketTest.cs
+++ b/Test/PacketType/EthernetPacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2008-2009 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/EthernetPacketTest.cs
+++ b/Test/PacketType/EthernetPacketTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/GreIPv6PacketTest.cs
+++ b/Test/PacketType/GreIPv6PacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2018 Steven Haufe<haufes@hotmail.com>

--- a/Test/PacketType/GreIPv6PacketTest.cs
+++ b/Test/PacketType/GreIPv6PacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2018 Steven Haufe<haufes@hotmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/PacketType/IPPacketTest.cs
+++ b/Test/PacketType/IPPacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/IPPacketTest.cs
+++ b/Test/PacketType/IPPacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/PacketType/IPv4PacketTest.cs
+++ b/Test/PacketType/IPv4PacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/IPv4PacketTest.cs
+++ b/Test/PacketType/IPv4PacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/PacketType/IPv6PacketTest.cs
+++ b/Test/PacketType/IPv6PacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/IPv6PacketTest.cs
+++ b/Test/PacketType/IPv6PacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/PacketType/IcmpV4PacketTest.cs
+++ b/Test/PacketType/IcmpV4PacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/IcmpV4PacketTest.cs
+++ b/Test/PacketType/IcmpV4PacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/PacketType/IcmpV6PacketTest.cs
+++ b/Test/PacketType/IcmpV6PacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/IcmpV6PacketTest.cs
+++ b/Test/PacketType/IcmpV6PacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/PacketType/Ieee80211/AcknowledgmentFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AcknowledgmentFrameTest.cs
@@ -1,5 +1,5 @@
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/AcknowledgmentFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AcknowledgmentFrameTest.cs
@@ -1,18 +1,9 @@
 /*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/ActionFrameTest.cs
+++ b/Test/PacketType/Ieee80211/ActionFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/ActionFrameTest.cs
+++ b/Test/PacketType/Ieee80211/ActionFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/AssociationRequestFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AssociationRequestFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/AssociationRequestFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AssociationRequestFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/AssociationResponseFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AssociationResponseFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/AssociationResponseFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AssociationResponseFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/AuthenticationFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AuthenticationFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/AuthenticationFrameTest.cs
+++ b/Test/PacketType/Ieee80211/AuthenticationFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/BeaconFrameTest.cs
+++ b/Test/PacketType/Ieee80211/BeaconFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/BeaconFrameTest.cs
+++ b/Test/PacketType/Ieee80211/BeaconFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/BlockAcknowledgmentControlFieldTest.cs
+++ b/Test/PacketType/Ieee80211/BlockAcknowledgmentControlFieldTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/BlockAcknowledgmentControlFieldTest.cs
+++ b/Test/PacketType/Ieee80211/BlockAcknowledgmentControlFieldTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/BlockAcknowledgmentFrameTest.cs
+++ b/Test/PacketType/Ieee80211/BlockAcknowledgmentFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/BlockAcknowledgmentFrameTest.cs
+++ b/Test/PacketType/Ieee80211/BlockAcknowledgmentFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/BlockAcknowledgmentRequestFrameTest.cs
+++ b/Test/PacketType/Ieee80211/BlockAcknowledgmentRequestFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/BlockAcknowledgmentRequestFrameTest.cs
+++ b/Test/PacketType/Ieee80211/BlockAcknowledgmentRequestFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/CapabilityInformationFieldTest.cs
+++ b/Test/PacketType/Ieee80211/CapabilityInformationFieldTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/CapabilityInformationFieldTest.cs
+++ b/Test/PacketType/Ieee80211/CapabilityInformationFieldTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/ContentionFreeEndFrameTest.cs
+++ b/Test/PacketType/Ieee80211/ContentionFreeEndFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/ContentionFreeEndFrameTest.cs
+++ b/Test/PacketType/Ieee80211/ContentionFreeEndFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/CtsFrameTest.cs
+++ b/Test/PacketType/Ieee80211/CtsFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/CtsFrameTest.cs
+++ b/Test/PacketType/Ieee80211/CtsFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/DataDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/DataDataFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/DataDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/DataDataFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/DeauthenticationFrameTest.cs
+++ b/Test/PacketType/Ieee80211/DeauthenticationFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/DeauthenticationFrameTest.cs
+++ b/Test/PacketType/Ieee80211/DeauthenticationFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/DisassociationFrameTest.cs
+++ b/Test/PacketType/Ieee80211/DisassociationFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/DisassociationFrameTest.cs
+++ b/Test/PacketType/Ieee80211/DisassociationFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/FrameControlFieldTest.cs
+++ b/Test/PacketType/Ieee80211/FrameControlFieldTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/FrameControlFieldTest.cs
+++ b/Test/PacketType/Ieee80211/FrameControlFieldTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/InformationElementListTest.cs
+++ b/Test/PacketType/Ieee80211/InformationElementListTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/InformationElementListTest.cs
+++ b/Test/PacketType/Ieee80211/InformationElementListTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/InformationElementTest.cs
+++ b/Test/PacketType/Ieee80211/InformationElementTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/InformationElementTest.cs
+++ b/Test/PacketType/Ieee80211/InformationElementTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/MacFrameTest.cs
+++ b/Test/PacketType/Ieee80211/MacFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/MacFrameTest.cs
+++ b/Test/PacketType/Ieee80211/MacFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/NullDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/NullDataFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/NullDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/NullDataFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/PerPacketInformationTest.cs
+++ b/Test/PacketType/Ieee80211/PerPacketInformationTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using NUnit.Framework;
 using PacketDotNet;

--- a/Test/PacketType/Ieee80211/PerPacketInformationTest.cs
+++ b/Test/PacketType/Ieee80211/PerPacketInformationTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/Ieee80211/ProbeRequestTest.cs
+++ b/Test/PacketType/Ieee80211/ProbeRequestTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/ProbeRequestTest.cs
+++ b/Test/PacketType/Ieee80211/ProbeRequestTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/ProbeResponseTest.cs
+++ b/Test/PacketType/Ieee80211/ProbeResponseTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/ProbeResponseTest.cs
+++ b/Test/PacketType/Ieee80211/ProbeResponseTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/QosDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/QosDataFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/QosDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/QosDataFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/QosNullDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/QosNullDataFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/QosNullDataFrameTest.cs
+++ b/Test/PacketType/Ieee80211/QosNullDataFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/Ieee80211/RadioPacketTest.cs
+++ b/Test/PacketType/Ieee80211/RadioPacketTest.cs
@@ -1,18 +1,9 @@
 /*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/Ieee80211/RadioPacketTest.cs
+++ b/Test/PacketType/Ieee80211/RadioPacketTest.cs
@@ -1,13 +1,10 @@
 /*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System.IO;
 using NUnit.Framework;

--- a/Test/PacketType/Ieee80211/RawPacketTest.cs
+++ b/Test/PacketType/Ieee80211/RawPacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using NUnit.Framework;
 using PacketDotNet;

--- a/Test/PacketType/Ieee80211/RawPacketTest.cs
+++ b/Test/PacketType/Ieee80211/RawPacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/Ieee80211/ReassociationRequestFrameTest.cs
+++ b/Test/PacketType/Ieee80211/ReassociationRequestFrameTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2012 Alan Rushforth <alan.rushforth@gmail.com>

--- a/Test/PacketType/Ieee80211/ReassociationRequestFrameTest.cs
+++ b/Test/PacketType/Ieee80211/ReassociationRequestFrameTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/PacketType/IgmpV2PacketTest.cs
+++ b/Test/PacketType/IgmpV2PacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/PacketType/IgmpV2PacketTest.cs
+++ b/Test/PacketType/IgmpV2PacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/Test/PacketType/L2tpPacketTest.cs
+++ b/Test/PacketType/L2tpPacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2018 Steven Haufe<haufes@hotmail.com>

--- a/Test/PacketType/L2tpPacketTest.cs
+++ b/Test/PacketType/L2tpPacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2018 Steven Haufe<haufes@hotmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/PacketType/LinkTypeNullCaptureTest.cs
+++ b/Test/PacketType/LinkTypeNullCaptureTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/LinkTypeNullCaptureTest.cs
+++ b/Test/PacketType/LinkTypeNullCaptureTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2017 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/PacketType/LinuxCookedCaptureTest.cs
+++ b/Test/PacketType/LinuxCookedCaptureTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/PacketType/LinuxCookedCaptureTest.cs
+++ b/Test/PacketType/LinuxCookedCaptureTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/LldpTest.cs
+++ b/Test/PacketType/LldpTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/PacketType/LldpTest.cs
+++ b/Test/PacketType/LldpTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/Test/PacketType/PppPacketTest.cs
+++ b/Test/PacketType/PppPacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/PacketType/PppPacketTest.cs
+++ b/Test/PacketType/PppPacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/Test/PacketType/PppoePppTest.cs
+++ b/Test/PacketType/PppoePppTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/PacketType/PppoePppTest.cs
+++ b/Test/PacketType/PppoePppTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/RawPacketTest.cs
+++ b/Test/PacketType/RawPacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/PacketType/RawPacketTest.cs
+++ b/Test/PacketType/RawPacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/Test/PacketType/TcpPacketTest.cs
+++ b/Test/PacketType/TcpPacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.Collections.Generic;

--- a/Test/PacketType/TcpPacketTest.cs
+++ b/Test/PacketType/TcpPacketTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/TeredoPacketTest.cs
+++ b/Test/PacketType/TeredoPacketTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2018 Steven Haufe<haufes@hotmail.com>
- */
 
 using NUnit.Framework;
 using PacketDotNet;

--- a/Test/PacketType/TeredoPacketTest.cs
+++ b/Test/PacketType/TeredoPacketTest.cs
@@ -1,15 +1,9 @@
 ﻿/*
 This file is part of PacketDotNet
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2018 Steven Haufe<haufes@hotmail.com>

--- a/Test/PacketType/UdpTest.cs
+++ b/Test/PacketType/UdpTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/PacketType/UdpTest.cs
+++ b/Test/PacketType/UdpTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/Vlan802_1QTest.cs
+++ b/Test/PacketType/Vlan802_1QTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2013 Chris Morgan <chmorgan@gmail.com>

--- a/Test/PacketType/Vlan802_1QTest.cs
+++ b/Test/PacketType/Vlan802_1QTest.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2013 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using NUnit.Framework;

--- a/Test/PacketType/WakeOnLanTest.cs
+++ b/Test/PacketType/WakeOnLanTest.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  * Copyright 2010 Evan Plaice <evanplaice@gmail.com>

--- a/Test/PacketType/WakeOnLanTest.cs
+++ b/Test/PacketType/WakeOnLanTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Test/Performance/BitConversionPerformance.cs
+++ b/Test/Performance/BitConversionPerformance.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>

--- a/Test/Performance/BitConversionPerformance.cs
+++ b/Test/Performance/BitConversionPerformance.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using System.IO;

--- a/Test/Performance/ByteRetrievalPerformance.cs
+++ b/Test/Performance/ByteRetrievalPerformance.cs
@@ -1,13 +1,10 @@
 ﻿/*
-This file is part of PacketDotNet
+This file is part of PacketDotNet.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
-/*
- *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>
- */
 
 using System;
 using log4net.Core;

--- a/Test/Performance/ByteRetrievalPerformance.cs
+++ b/Test/Performance/ByteRetrievalPerformance.cs
@@ -1,18 +1,9 @@
-/*
+﻿/*
 This file is part of PacketDotNet
 
-PacketDotNet is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-PacketDotNet is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with PacketDotNet.  If not, see <http://www.gnu.org/licenses/>.
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 /*
  *  Copyright 2010 Chris Morgan <chmorgan@gmail.com>


### PR DESCRIPTION
Helps to accomodate the use single file deployments found in .NET 5.0.

List of contributors that have approved the transition to the new license:

  Chris Morgan
  Lex Li
  Ayoub Kaanich
  Jan Pluskal
  Cameron Elliott
  Georgi Baychev
  Dustin Green
  Alan Rushforth
  Di Pan
  Evan Plaice
  Steven Haufe
  Phyxion